### PR TITLE
[BLOOM-26] Swagger 설정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ allOpen {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     runtimeOnly("com.mysql:mysql-connector-j")

--- a/src/main/kotlin/dnd11th/blooming/api/config/SwaggerConfig.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/config/SwaggerConfig.kt
@@ -27,25 +27,10 @@ class SwaggerConfig {
 
     @Bean
     fun springOpenApi(): OpenAPI {
-        val tokenSchema: SecurityScheme =
-            SecurityScheme()
-                .type(SecurityScheme.Type.HTTP)
-                .scheme("bearer")
-                .bearerFormat("JWT")
-                .name(AUTHORIZATION)
-                .`in`(SecurityScheme.In.HEADER)
-
-        val securityItem: SecurityRequirement = SecurityRequirement().addList(AUTHORIZATION)
-
         return OpenAPI()
-            .components(Components().addSecuritySchemes(AUTHORIZATION, tokenSchema))
-            .addSecurityItem(securityItem)
-            .info(
-                Info()
-                    .title("\uD83C\uDF40Blomming\uD83C\uDF40")
-                    .description("API 명세서입니다")
-                    .title("v0.0.1"),
-            )
+            .components(swaggerComponent())
+            .addSecurityItem(securityItem())
+            .info(swaggerInfo())
     }
 
     @Bean
@@ -60,6 +45,31 @@ class SwaggerConfig {
             }
             operation
         }
+
+    private fun swaggerComponent(): Components {
+        val tokenSchema: SecurityScheme =
+            SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .name(AUTHORIZATION)
+                .`in`(SecurityScheme.In.HEADER)
+
+        return Components()
+            .addSecuritySchemes(AUTHORIZATION, tokenSchema)
+    }
+
+    private fun securityItem(): SecurityRequirement {
+        return SecurityRequirement()
+            .addList(AUTHORIZATION)
+    }
+
+    private fun swaggerInfo(): Info {
+        return Info()
+            .title("\uD83C\uDF40Blomming\uD83C\uDF40")
+            .description("API 명세서입니다")
+            .title("v0.0.1")
+    }
 
     private fun generateErrorResponse(
         operation: Operation,

--- a/src/main/kotlin/dnd11th/blooming/api/config/SwaggerConfig.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/config/SwaggerConfig.kt
@@ -68,7 +68,7 @@ class SwaggerConfig {
     ) {
         val responses = operation.responses
         val exampleDto = createExampleDto(errorCode)
-        addExamplesToApiResponse(responses, description, exampleDto)
+        addExampleToApiResponse(responses, description, exampleDto)
     }
 
     private fun createExampleDto(errorCode: ErrorType): ExampleDto {
@@ -82,7 +82,7 @@ class SwaggerConfig {
         )
     }
 
-    private fun addExamplesToApiResponse(
+    private fun addExampleToApiResponse(
         responses: ApiResponses,
         description: String,
         exampleDto: ExampleDto,

--- a/src/main/kotlin/dnd11th/blooming/api/config/SwaggerConfig.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/config/SwaggerConfig.kt
@@ -1,0 +1,111 @@
+package dnd11th.blooming.api.config
+
+import dnd11th.blooming.common.annotation.ApiErrorResponse
+import dnd11th.blooming.common.annotation.ApiErrorResponses
+import dnd11th.blooming.common.exception.ErrorResponse
+import dnd11th.blooming.common.exception.ErrorType
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.examples.Example
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.media.Content
+import io.swagger.v3.oas.models.media.MediaType
+import io.swagger.v3.oas.models.responses.ApiResponse
+import io.swagger.v3.oas.models.responses.ApiResponses
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springdoc.core.customizers.OperationCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConfig {
+    companion object {
+        const val AUTHORIZATION = "bearerToken"
+    }
+
+    @Bean
+    fun springOpenApi(): OpenAPI {
+        val tokenSchema: SecurityScheme =
+            SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .name(AUTHORIZATION)
+                .`in`(SecurityScheme.In.HEADER)
+
+        val securityItem: SecurityRequirement = SecurityRequirement().addList(AUTHORIZATION)
+
+        return OpenAPI()
+            .components(Components().addSecuritySchemes(AUTHORIZATION, tokenSchema))
+            .addSecurityItem(securityItem)
+            .info(
+                Info()
+                    .title("\uD83C\uDF40Blomming\uD83C\uDF40")
+                    .description("API 명세서입니다")
+                    .title("v0.0.1"),
+            )
+    }
+
+    @Bean
+    fun customize(): OperationCustomizer =
+        OperationCustomizer { operation, handlerMethod ->
+            handlerMethod.getMethodAnnotation(ApiErrorResponses::class.java)?.let { apiErrorResponses ->
+                apiErrorResponses.value.forEach { value ->
+                    generateErrorResponse(operation, value.errorType, value.description)
+                }
+            } ?: handlerMethod.getMethodAnnotation(ApiErrorResponse::class.java)?.let { apiErrorResponse ->
+                generateErrorResponse(operation, apiErrorResponse.errorType, apiErrorResponse.description)
+            }
+            operation
+        }
+
+    private fun generateErrorResponse(
+        operation: Operation,
+        errorCode: ErrorType,
+        description: String,
+    ) {
+        val responses = operation.responses
+        val exampleDto = createExampleDto(errorCode)
+        addExamplesToApiResponse(responses, description, exampleDto)
+    }
+
+    private fun createExampleDto(errorCode: ErrorType): ExampleDto {
+        val error = ErrorResponse.from(errorCode)
+        val example =
+            Example().apply { this.value(error) }
+        return ExampleDto(
+            name = errorCode.name,
+            code = errorCode.status.value(),
+            holder = example,
+        )
+    }
+
+    private fun addExamplesToApiResponse(
+        responses: ApiResponses,
+        description: String,
+        exampleDto: ExampleDto,
+    ) {
+        val mediaType =
+            MediaType().apply {
+                addExamples(exampleDto.name, exampleDto.holder)
+            }
+        val content =
+            Content().apply {
+                addMediaType("application/json", mediaType)
+            }
+        val apiResponse =
+            ApiResponse().apply {
+                this.content = content
+                this.description = description
+            }
+        responses.addApiResponse(exampleDto.code.toString(), apiResponse)
+    }
+
+    data class ExampleDto(
+        val name: String,
+        val code: Int,
+        val holder: Example,
+    )
+}

--- a/src/main/kotlin/dnd11th/blooming/api/controller/HealthApi.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/HealthApi.kt
@@ -1,12 +1,16 @@
 package dnd11th.blooming.api.controller
 
+import dnd11th.blooming.common.annotation.ApiErrorResponse
+import dnd11th.blooming.common.exception.ErrorType
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 
 @Tag(name = "1. [헬스체크]")
 interface HealthApi {
-
     @Operation(summary = "헬스 체크 API 입니다.")
-    fun healthCheck() : ResponseEntity<String>
+    @ApiResponse(responseCode = "200", description = "서버가 정상적으로 동작할 시 ok를 응답합니다.")
+    @ApiErrorResponse(errorType = ErrorType.SERVER_ERROR, description = "서버 에러입니다. 백엔드 긴급호출~")
+    fun healthCheck(): ResponseEntity<String>
 }

--- a/src/main/kotlin/dnd11th/blooming/api/controller/HealthApi.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/HealthApi.kt
@@ -1,0 +1,12 @@
+package dnd11th.blooming.api.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+
+@Tag(name = "1. [헬스체크]")
+interface HealthApi {
+
+    @Operation(summary = "헬스 체크 API 입니다.")
+    fun healthCheck() : ResponseEntity<String>
+}

--- a/src/main/kotlin/dnd11th/blooming/api/controller/HealthController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/HealthController.kt
@@ -1,0 +1,16 @@
+package dnd11th.blooming.api.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api")
+class HealthController : HealthApi {
+
+    @GetMapping("/health")
+    override fun healthCheck() : ResponseEntity<String> {
+        return ResponseEntity.ok().body("ok")
+    }
+}

--- a/src/main/kotlin/dnd11th/blooming/api/controller/HealthController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/HealthController.kt
@@ -8,9 +8,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api")
 class HealthController : HealthApi {
-
     @GetMapping("/health")
-    override fun healthCheck() : ResponseEntity<String> {
+    override fun healthCheck(): ResponseEntity<String> {
         return ResponseEntity.ok().body("ok")
     }
 }

--- a/src/main/kotlin/dnd11th/blooming/api/service/user/oauth/KakaoOauthProperties.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/user/oauth/KakaoOauthProperties.kt
@@ -2,7 +2,7 @@ package dnd11th.blooming.api.service.user.oauth
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 
-@ConfigurationProperties(value = "auth.oidc.provider.kakao")
+@ConfigurationProperties(prefix = "auth.oidc.provider.kakao")
 data class KakaoOauthProperties(
     val iss: String,
     val aud: String,

--- a/src/main/kotlin/dnd11th/blooming/common/annotation/ApiErrorResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/annotation/ApiErrorResponse.kt
@@ -1,0 +1,10 @@
+package dnd11th.blooming.common.annotation
+
+import dnd11th.blooming.common.exception.ErrorType
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ApiErrorResponse(
+    val errorType: ErrorType,
+    val description: String,
+)

--- a/src/main/kotlin/dnd11th/blooming/common/annotation/ApiErrorResponses.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/annotation/ApiErrorResponses.kt
@@ -1,0 +1,7 @@
+package dnd11th.blooming.common.annotation
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ApiErrorResponses(
+    val value: Array<ApiErrorResponse>,
+)

--- a/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
@@ -4,6 +4,9 @@ import org.springframework.boot.logging.LogLevel
 import org.springframework.http.HttpStatus
 
 enum class ErrorType(val status: HttpStatus, val message: String, val logLevel: LogLevel) {
+    // COMMON
+    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error has occurred.", LogLevel.ERROR),
+
     INVALID_DATE(HttpStatus.BAD_REQUEST, "올바르지 않은 날짜입니다.", LogLevel.DEBUG),
     NOT_FOUND_MYPLANT_ID(HttpStatus.NOT_FOUND, "존재하지 않는 내 식물입니다.", LogLevel.DEBUG),
     NOT_FOUND_LOCATION_ID(HttpStatus.NOT_FOUND, "존재하지 않는 위치입니다.", LogLevel.DEBUG),

--- a/src/main/kotlin/dnd11th/blooming/common/jwt/JwtProperties.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/jwt/JwtProperties.kt
@@ -2,7 +2,7 @@ package dnd11th.blooming.common.jwt
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 
-@ConfigurationProperties(value = "auth.jwt")
+@ConfigurationProperties(prefix = "auth.jwt")
 data class JwtProperties(
     val access: TokenProperties,
     val refresh: TokenProperties,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,7 @@ spring:
     hibernate:
       ddl-auto: update
     defer-datasource-initialization: true
+    open-in-view: false
 
 auth:
   jwt:


### PR DESCRIPTION
Close #26 

<!-- 제목은 아래처럼 -->
<!-- [BLOOM-001] PR 제목 -->

> ### How
<!-- 해당 테스크를 수행하기 위한 과정과 흐름에 대해 집중해서 작성해주세요. -->
- Swagger를 설정했습니다.
- ApiErrorResponse, ApiErrorResponses 어노테이션을 추가하였습니다.
- Swagger 커스터마이징을 통해 error 응답을 다 적는 것이 아닌, ErrorType을 주입받아 해결하도록 하였습니다.
- Swagger를 사용할 때 ~Api 인터페이스를 작성해 Swagger 어노테이션을 작성하면, Controller에 Swagger 관련 코드가 침투되지 않습니다.
> ### Result
<!-- 해당 테스크를 통한 결과에 대해 짧게 작성해주세요. -->
<!-- 작업한 내용, 스크린샷 -->
Before
![스크린샷 2024-08-06 오후 11 47 49](https://github.com/user-attachments/assets/d07ec0dc-327d-4bc7-9722-1a6cc5986fac)

After
![스크린샷 2024-08-06 오후 11 37 51](https://github.com/user-attachments/assets/c508cb95-a723-490d-80c0-3db2e255b206)

> ### Prize
<!-- 해당 테스크를 통해서 어떤 기술적 성취가 있었는지 작성해주세요. -->
<!-- !! 사용하지 않는다면 삭제해주세요. -->
- Swagger를 커스터마이징 할 수 있습니다.
- 적절한 어노테이션을 사용할 수 있습니다.

