### PR TITLE
[BLOOM-033] 이미지 관련 api 개발

### DIFF
--- a/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
@@ -1,7 +1,9 @@
 package dnd11th.blooming.api.controller.image
 
+import dnd11th.blooming.api.dto.image.ImageFavoriteModifyRequest
 import dnd11th.blooming.api.dto.image.ImageSaveRequest
 import dnd11th.blooming.api.service.image.ImageService
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -19,4 +21,10 @@ class ImageController(
         @PathVariable myPlantId: Long,
         @RequestBody request: ImageSaveRequest,
     ) = imageService.saveImage(myPlantId, request, LocalDate.now())
+
+    @PatchMapping("/image/{imageId}")
+    fun modifyFavorite(
+        @PathVariable imageId: Long,
+        @RequestBody request: ImageFavoriteModifyRequest,
+    ) = imageService.modifyFavorite(imageId, request)
 }

--- a/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
@@ -1,0 +1,22 @@
+package dnd11th.blooming.api.controller.image
+
+import dnd11th.blooming.api.dto.image.ImageSaveRequest
+import dnd11th.blooming.api.service.image.ImageService
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+@RestController
+@RequestMapping("/api/v1/myplants")
+class ImageController(
+    private val imageService: ImageService,
+) {
+    @PostMapping("/{myPlantId}/image")
+    fun saveImage(
+        @PathVariable myPlantId: Long,
+        @RequestBody request: ImageSaveRequest,
+    ) = imageService.saveImage(myPlantId, request, LocalDate.now())
+}

--- a/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
@@ -3,6 +3,7 @@ package dnd11th.blooming.api.controller.image
 import dnd11th.blooming.api.dto.image.ImageFavoriteModifyRequest
 import dnd11th.blooming.api.dto.image.ImageSaveRequest
 import dnd11th.blooming.api.service.image.ImageService
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -27,4 +28,9 @@ class ImageController(
         @PathVariable imageId: Long,
         @RequestBody request: ImageFavoriteModifyRequest,
     ) = imageService.modifyFavorite(imageId, request)
+
+    @DeleteMapping("/image/{imageId}")
+    fun deleteImage(
+        @PathVariable imageId: Long,
+    ) = imageService.deleteImage(imageId)
 }

--- a/src/main/kotlin/dnd11th/blooming/api/dto/home/HomeResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/home/HomeResponse.kt
@@ -3,6 +3,7 @@ package dnd11th.blooming.api.dto.home
 data class HomeResponse(
     val greetingMessage: String,
     val myPlantInfo: List<MyPlantHomeResponse>,
+    // TODO : 식물 일러스트 응답 추가 필요
 ) {
     companion object {
         fun from(

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageFavoriteModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageFavoriteModifyRequest.kt
@@ -1,0 +1,5 @@
+package dnd11th.blooming.api.dto.image
+
+data class ImageFavoriteModifyRequest(
+    val favorite: Boolean,
+)

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageResponse.kt
@@ -1,0 +1,24 @@
+package dnd11th.blooming.api.dto.image
+
+import dnd11th.blooming.domain.entity.Image
+import java.time.LocalDate
+
+data class ImageResponse(
+    val imageUrl: String,
+    val favorite: Boolean,
+    val createdDate: LocalDate,
+) {
+    companion object {
+        fun from(image: Image): ImageResponse =
+            ImageResponse(
+                imageUrl = image.url,
+                favorite = image.favorite,
+                createdDate = image.createdDate,
+            )
+
+        fun fromList(images: List<Image>): List<ImageResponse> =
+            images.stream()
+                .map { image -> from(image) }
+                .toList()
+    }
+}

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageSaveRequest.kt
@@ -1,15 +1,21 @@
 package dnd11th.blooming.api.dto.image
 
 import dnd11th.blooming.domain.entity.Image
+import dnd11th.blooming.domain.entity.MyPlant
 import java.time.LocalDate
 
 data class ImageSaveRequest(
     val imageUrl: String,
 ) {
-    fun toImage(now: LocalDate): Image =
+    fun toImage(
+        myPlant: MyPlant,
+        now: LocalDate,
+    ): Image =
         Image(
             url = imageUrl,
             favorite = false,
             currentDate = now,
-        )
+        ).also {
+            it.setMyPlantRelation(myPlant)
+        }
 }

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageSaveRequest.kt
@@ -1,0 +1,15 @@
+package dnd11th.blooming.api.dto.image
+
+import dnd11th.blooming.domain.entity.Image
+import java.time.LocalDate
+
+data class ImageSaveRequest(
+    val imageUrl: String,
+) {
+    fun toImage(now: LocalDate): Image =
+        Image(
+            url = imageUrl,
+            favorite = false,
+            currentDate = now,
+        )
+}

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantDetailResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantDetailResponse.kt
@@ -1,6 +1,8 @@
 package dnd11th.blooming.api.dto.myplant
 
+import dnd11th.blooming.api.dto.image.ImageResponse
 import dnd11th.blooming.api.service.myplant.MyPlantMessageFactory
+import dnd11th.blooming.domain.entity.Image
 import dnd11th.blooming.domain.entity.MyPlant
 import java.time.LocalDate
 
@@ -19,11 +21,13 @@ data class MyPlantDetailResponse(
     val fertilizerAlarm: Boolean,
     val fertilizerPeriod: Int?,
     val healthCheckAlarm: Boolean,
+    val images: List<ImageResponse>,
 ) {
     companion object {
         fun of(
             myPlant: MyPlant,
             messageFactory: MyPlantMessageFactory,
+            images: List<Image>,
             now: LocalDate,
         ): MyPlantDetailResponse =
             MyPlantDetailResponse(
@@ -49,6 +53,7 @@ data class MyPlantDetailResponse(
                 fertilizerAlarm = myPlant.alarm.fertilizerAlarm,
                 fertilizerPeriod = myPlant.alarm.fertilizerPeriod,
                 healthCheckAlarm = myPlant.alarm.healthCheckAlarm,
+                images = ImageResponse.fromList(images),
             )
     }
 }

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantModifyRequest.kt
@@ -4,7 +4,7 @@ import java.time.LocalDate
 
 data class MyPlantModifyRequest(
     val nickname: String?,
-    val location: String?,
+    val locationId: Long?,
     val startDate: LocalDate?,
     val lastWateredDate: LocalDate?,
     val lastFertilizerDate: LocalDate?,

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
@@ -1,6 +1,7 @@
 package dnd11th.blooming.api.dto.myplant
 
 import dnd11th.blooming.domain.entity.Alarm
+import dnd11th.blooming.domain.entity.Location
 import dnd11th.blooming.domain.entity.MyPlant
 import java.time.LocalDate
 
@@ -17,13 +18,17 @@ data class MyPlantSaveRequest(
     val fertilizerPeriod: Int?,
     val healthCheckAlarm: Boolean,
 ) {
-    fun toMyPlant(): MyPlant =
+    fun toMyPlant(
+        location: Location,
+        now: LocalDate,
+    ): MyPlant =
         MyPlant(
             scientificName = scientificName,
             nickname = nickname,
             startDate = startDate,
             lastWateredDate = lastWateredDate,
             lastFertilizerDate = lastFertilizerDate,
+            currentDate = now,
             alarm =
                 Alarm(
                     waterAlarm = waterAlarm,
@@ -32,5 +37,9 @@ data class MyPlantSaveRequest(
                     fertilizerPeriod = fertilizerPeriod,
                     healthCheckAlarm = healthCheckAlarm,
                 ),
-        )
+        ).also {
+            it.setLocationRelation(location)
+            // TODO : 유저와 매핑 필요
+            // TODO : 식물가이드와 매핑 필요
+        }
 }

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
@@ -7,6 +7,7 @@ import java.time.LocalDate
 data class MyPlantSaveRequest(
     val scientificName: String,
     val nickname: String,
+    val locationId: Long,
     val startDate: LocalDate,
     val lastWateredDate: LocalDate,
     val lastFertilizerDate: LocalDate,

--- a/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
@@ -1,0 +1,35 @@
+package dnd11th.blooming.api.service.image
+
+import dnd11th.blooming.api.dto.image.ImageSaveRequest
+import dnd11th.blooming.common.exception.ErrorType
+import dnd11th.blooming.common.exception.NotFoundException
+import dnd11th.blooming.domain.repository.ImageRepository
+import dnd11th.blooming.domain.repository.MyPlantRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Service
+class ImageService(
+    private val myPlantRepository: MyPlantRepository,
+    private val imageRepository: ImageRepository,
+) {
+    @Transactional
+    fun saveImage(
+        myPlantId: Long,
+        request: ImageSaveRequest,
+        now: LocalDate,
+    ) {
+        val myPlant =
+            myPlantRepository.findByIdOrNull(myPlantId)
+                ?: throw NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
+
+        val image =
+            request.toImage(now).also {
+                it.makeMyPlantRelation(myPlant)
+            }
+
+        imageRepository.save(image)
+    }
+}

--- a/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
@@ -26,10 +26,9 @@ class ImageService(
             myPlantRepository.findByIdOrNull(myPlantId)
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
 
-        val image =
-            request.toImage(now).also {
-                it.setMyPlantRelation(myPlant)
-            }
+        val image = request.toImage(now)
+
+        image.setMyPlantRelation(myPlant)
 
         imageRepository.save(image)
     }

--- a/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
@@ -1,5 +1,6 @@
 package dnd11th.blooming.api.service.image
 
+import dnd11th.blooming.api.dto.image.ImageFavoriteModifyRequest
 import dnd11th.blooming.api.dto.image.ImageSaveRequest
 import dnd11th.blooming.common.exception.ErrorType
 import dnd11th.blooming.common.exception.NotFoundException
@@ -31,5 +32,15 @@ class ImageService(
             }
 
         imageRepository.save(image)
+    }
+
+    @Transactional
+    fun modifyFavorite(
+        imageId: Long,
+        request: ImageFavoriteModifyRequest,
+    ) {
+        val image = imageRepository.findByIdOrNull(imageId) ?: throw NotFoundException(ErrorType.NOT_FOUND_IMAGE)
+
+        image.modifyFavorite(request.favorite)
     }
 }

--- a/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
@@ -26,9 +26,7 @@ class ImageService(
             myPlantRepository.findByIdOrNull(myPlantId)
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
 
-        val image = request.toImage(now)
-
-        image.setMyPlantRelation(myPlant)
+        val image = request.toImage(myPlant, now)
 
         imageRepository.save(image)
     }

--- a/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
@@ -28,7 +28,7 @@ class ImageService(
 
         val image =
             request.toImage(now).also {
-                it.makeMyPlantRelation(myPlant)
+                it.setMyPlantRelation(myPlant)
             }
 
         imageRepository.save(image)

--- a/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
@@ -23,7 +23,8 @@ class ImageService(
         now: LocalDate,
     ) {
         val myPlant =
-            myPlantRepository.findByIdOrNull(myPlantId)
+            myPlantRepository
+                .findByIdOrNull(myPlantId)
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
 
         val image =
@@ -39,8 +40,20 @@ class ImageService(
         imageId: Long,
         request: ImageFavoriteModifyRequest,
     ) {
-        val image = imageRepository.findByIdOrNull(imageId) ?: throw NotFoundException(ErrorType.NOT_FOUND_IMAGE)
+        val image =
+            imageRepository
+                .findByIdOrNull(imageId)
+                ?: throw NotFoundException(ErrorType.NOT_FOUND_IMAGE)
 
         image.modifyFavorite(request.favorite)
+    }
+
+    @Transactional
+    fun deleteImage(imageId: Long) {
+        if (imageRepository.existsById(imageId)) {
+            throw NotFoundException(ErrorType.NOT_FOUND_IMAGE)
+        }
+
+        imageRepository.deleteById(imageId)
     }
 }

--- a/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
@@ -23,8 +23,7 @@ class ImageService(
         now: LocalDate,
     ) {
         val myPlant =
-            myPlantRepository
-                .findByIdOrNull(myPlantId)
+            myPlantRepository.findByIdOrNull(myPlantId)
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
 
         val image =
@@ -41,8 +40,7 @@ class ImageService(
         request: ImageFavoriteModifyRequest,
     ) {
         val image =
-            imageRepository
-                .findByIdOrNull(imageId)
+            imageRepository.findByIdOrNull(imageId)
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_IMAGE)
 
         image.modifyFavorite(request.favorite)

--- a/src/main/kotlin/dnd11th/blooming/api/service/location/LocationService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/location/LocationService.kt
@@ -17,6 +17,7 @@ class LocationService(
 ) {
     @Transactional
     fun saveLocation(request: LocationSaveRequest): LocationSaveResponse {
+        // TODO : 유저와 매핑 필요
         val location = request.toLocation()
         return LocationSaveResponse.from(locationRepository.save(location))
     }
@@ -46,6 +47,8 @@ class LocationService(
         if (!locationRepository.existsById(locationId)) {
             throw NotFoundException(ErrorType.NOT_FOUND_LOCATION)
         }
+
+        // TODO : Location 삭제시 그 안에 있던 식물들을 어떻게 다룰지 추가 작성 필요
 
         locationRepository.deleteById(locationId)
     }

--- a/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
@@ -41,10 +41,9 @@ class MyPlantService(
                 .findByIdOrNull(request.locationId)
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_LOCATION)
 
-        val myPlant =
-            request.toMyPlant().also {
-                it.setLocationRelation(location)
-            }
+        val myPlant = request.toMyPlant()
+
+        myPlant.setLocationRelation(location)
         // TODO : 유저와 매핑 필요
         // TODO : 식물가이드와 매핑 필요
 

--- a/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
@@ -92,8 +92,8 @@ class MyPlantService(
         myPlant.modify(
             nickname = request.nickname,
             location =
-                request.location?.let {
-                    locationRepository.findByName(request.location)
+                request.locationId?.let {
+                    locationRepository.findByIdOrNull(request.locationId)
                         ?: throw NotFoundException(ErrorType.NOT_FOUND_LOCATION)
                 },
             startDate = request.startDate,

--- a/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
@@ -108,6 +108,7 @@ class MyPlantService(
             myPlantRepository.findByIdOrNull(myPlantId)
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
 
+        imageRepository.deleteAllByMyPlant(myPlant)
         myPlantRepository.delete(myPlant)
     }
 

--- a/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
@@ -12,6 +12,7 @@ import dnd11th.blooming.common.exception.ErrorType
 import dnd11th.blooming.common.exception.InvalidDateException
 import dnd11th.blooming.common.exception.NotFoundException
 import dnd11th.blooming.domain.entity.MyPlant
+import dnd11th.blooming.domain.repository.ImageRepository
 import dnd11th.blooming.domain.repository.LocationRepository
 import dnd11th.blooming.domain.repository.MyPlantRepository
 import org.springframework.data.repository.findByIdOrNull
@@ -24,6 +25,7 @@ class MyPlantService(
     private val myPlantRepository: MyPlantRepository,
     private val locationRepository: LocationRepository,
     private val myPlantMessageFactory: MyPlantMessageFactory,
+    private val imageRepository: ImageRepository,
 ) {
     @Transactional
     fun saveMyPlant(
@@ -63,7 +65,9 @@ class MyPlantService(
             myPlantRepository.findByIdOrNull(myPlantId)
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
 
-        return MyPlantDetailResponse.of(myPlant, myPlantMessageFactory, now)
+        val myPlantImages = imageRepository.findAllByMyPlant(myPlant)
+
+        return MyPlantDetailResponse.of(myPlant, myPlantMessageFactory, myPlantImages, now)
     }
 
     @Transactional

--- a/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
@@ -108,7 +108,7 @@ class MyPlantService(
             myPlantRepository.findByIdOrNull(myPlantId)
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
 
-        imageRepository.deleteAllByMyPlant(myPlant)
+        imageRepository.deleteAllInBatchByMyPlant(myPlant)
         myPlantRepository.delete(myPlant)
     }
 

--- a/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
@@ -36,7 +36,15 @@ class MyPlantService(
         validateDateNotInFuture(request.lastWateredDate, now)
         validateDateNotInFuture(request.lastFertilizerDate, now)
 
-        val myPlant = request.toMyPlant()
+        val location =
+            locationRepository
+                .findByIdOrNull(request.locationId)
+                ?: throw NotFoundException(ErrorType.NOT_FOUND_LOCATION)
+
+        val myPlant =
+            request.toMyPlant().also {
+                it.setLocationRelation(location)
+            }
 
         val savedPlant = myPlantRepository.save(myPlant)
 

--- a/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
@@ -45,6 +45,8 @@ class MyPlantService(
             request.toMyPlant().also {
                 it.setLocationRelation(location)
             }
+        // TODO : 유저와 매핑 필요
+        // TODO : 식물가이드와 매핑 필요
 
         val savedPlant = myPlantRepository.save(myPlant)
 

--- a/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
@@ -41,11 +41,7 @@ class MyPlantService(
                 .findByIdOrNull(request.locationId)
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_LOCATION)
 
-        val myPlant = request.toMyPlant()
-
-        myPlant.setLocationRelation(location)
-        // TODO : 유저와 매핑 필요
-        // TODO : 식물가이드와 매핑 필요
+        val myPlant = request.toMyPlant(location, now)
 
         val savedPlant = myPlantRepository.save(myPlant)
 

--- a/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
@@ -6,14 +6,21 @@ import org.springframework.http.HttpStatus
 enum class ErrorType(val status: HttpStatus, val message: String, val logLevel: LogLevel) {
     // COMMON
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error has occurred.", LogLevel.ERROR),
-
     INVALID_DATE(HttpStatus.BAD_REQUEST, "올바르지 않은 날짜입니다.", LogLevel.DEBUG),
+
+    // MyPlant
     NOT_FOUND_MYPLANT(HttpStatus.NOT_FOUND, "존재하지 않는 내 식물입니다.", LogLevel.DEBUG),
+
+    // Image
+    NOT_FOUND_IMAGE(HttpStatus.NOT_FOUND, "존재하지 않는 이미지입니다.", LogLevel.DEBUG),
+
+    // Location
     NOT_FOUND_LOCATION(HttpStatus.NOT_FOUND, "존재하지 않는 위치입니다.", LogLevel.DEBUG),
 
     // Auth
     INVALID_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다", LogLevel.DEBUG),
     INVALID_ID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 ID TOKEN입니다.", LogLevel.DEBUG),
+
     INVALID_OAUTH_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 provider입니다", LogLevel.DEBUG),
 
     // User

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/BaseEntity.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/BaseEntity.kt
@@ -1,0 +1,20 @@
+package dnd11th.blooming.domain.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.MappedSuperclass
+import jakarta.persistence.PreUpdate
+import java.time.LocalDate
+
+@MappedSuperclass
+abstract class BaseEntity(
+    @Column(name = "created_date", updatable = false)
+    var createdDate: LocalDate = LocalDate.now(),
+) {
+    @Column(name = "updated_date")
+    var updatedDate: LocalDate = LocalDate.now()
+
+    @PreUpdate
+    protected fun onUpdate() {
+        updatedDate = LocalDate.now()
+    }
+}

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/Image.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/Image.kt
@@ -29,4 +29,8 @@ class Image(
     fun makeMyPlantRelation(myPlant: MyPlant) {
         this.myPlant = myPlant
     }
+
+    fun modifyFavorite(favorite: Boolean) {
+        this.favorite = favorite
+    }
 }

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/Image.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/Image.kt
@@ -25,4 +25,8 @@ class Image(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "myplant_id")
     var myPlant: MyPlant? = null
+
+    fun makeMyPlantRelation(myPlant: MyPlant) {
+        this.myPlant = myPlant
+    }
 }

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/Image.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/Image.kt
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
+import java.time.LocalDate
 
 @Entity
 class Image(
@@ -15,7 +16,8 @@ class Image(
     var url: String,
     @Column
     var favorite: Boolean,
-) {
+    currentDate: LocalDate = LocalDate.now(),
+) : BaseEntity(currentDate) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/Image.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/Image.kt
@@ -1,0 +1,26 @@
+package dnd11th.blooming.domain.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+
+@Entity
+class Image(
+    @Column
+    var url: String,
+    @Column
+    var favorite: Boolean,
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "myplant_id")
+    var myPlant: MyPlant? = null
+}

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/Image.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/Image.kt
@@ -26,7 +26,7 @@ class Image(
     @JoinColumn(name = "myplant_id")
     var myPlant: MyPlant? = null
 
-    fun makeMyPlantRelation(myPlant: MyPlant) {
+    fun setMyPlantRelation(myPlant: MyPlant) {
         this.myPlant = myPlant
     }
 

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/Location.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/Location.kt
@@ -9,12 +9,14 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
+import java.time.LocalDate
 
 @Entity
 class Location(
     @Column
     var name: String,
-) {
+    currentDate: LocalDate = LocalDate.now(),
+) : BaseEntity(currentDate) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/MyPlant.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/MyPlant.kt
@@ -20,8 +20,6 @@ class MyPlant(
     @Column
     var nickname: String,
     @Column
-    var createdDate: LocalDate = LocalDate.now(),
-    @Column
     var startDate: LocalDate = LocalDate.now(),
     @Column
     var lastWateredDate: LocalDate = LocalDate.now(),
@@ -29,7 +27,8 @@ class MyPlant(
     var lastFertilizerDate: LocalDate = LocalDate.now(),
     @Embedded
     var alarm: Alarm,
-) {
+    currentDate: LocalDate = LocalDate.now(),
+) : BaseEntity(currentDate) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/MyPlant.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/MyPlant.kt
@@ -41,6 +41,10 @@ class MyPlant(
     @JoinColumn(name = "location_id")
     var location: Location? = null
 
+    fun setLocationRelation(location: Location) {
+        this.location = location
+    }
+
     fun modify(
         nickname: String?,
         location: Location?,

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/user/User.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/user/User.kt
@@ -1,17 +1,20 @@
 package dnd11th.blooming.domain.entity.user
 
+import dnd11th.blooming.domain.entity.BaseEntity
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import java.time.LocalDate
 
 @Entity
 @Table(name = "users")
 class User(
     email: String,
     nickname: String,
-) {
+    currentDate: LocalDate = LocalDate.now(),
+) : BaseEntity(currentDate) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/user/UserOauthInfo.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/user/UserOauthInfo.kt
@@ -1,5 +1,6 @@
 package dnd11th.blooming.domain.entity.user
 
+import dnd11th.blooming.domain.entity.BaseEntity
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
@@ -8,13 +9,15 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
+import java.time.LocalDate
 
 @Entity
 class UserOauthInfo(
     user: User,
     email: String,
     provider: OauthProvider,
-) {
+    currentDate: LocalDate = LocalDate.now(),
+) : BaseEntity(currentDate) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null

--- a/src/main/kotlin/dnd11th/blooming/domain/repository/ImageRepository.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/repository/ImageRepository.kt
@@ -3,9 +3,20 @@ package dnd11th.blooming.domain.repository
 import dnd11th.blooming.domain.entity.Image
 import dnd11th.blooming.domain.entity.MyPlant
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface ImageRepository : JpaRepository<Image, Long> {
     fun findAllByMyPlant(myPlant: MyPlant): List<Image>
 
-    fun deleteAllByMyPlant(myPlant: MyPlant)
+    @Modifying
+    @Query(
+        """
+		DELETE FROM Image i WHERE i.myPlant = :myPlant
+	""",
+    )
+    fun deleteAllInBatchByMyPlant(
+        @Param("myPlant") myPlant: MyPlant,
+    )
 }

--- a/src/main/kotlin/dnd11th/blooming/domain/repository/ImageRepository.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/repository/ImageRepository.kt
@@ -1,6 +1,9 @@
 package dnd11th.blooming.domain.repository
 
 import dnd11th.blooming.domain.entity.Image
+import dnd11th.blooming.domain.entity.MyPlant
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface ImageRepository : JpaRepository<Image, Long>
+interface ImageRepository : JpaRepository<Image, Long> {
+    fun findAllByMyPlant(myPlant: MyPlant): List<Image>
+}

--- a/src/main/kotlin/dnd11th/blooming/domain/repository/ImageRepository.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/repository/ImageRepository.kt
@@ -1,0 +1,6 @@
+package dnd11th.blooming.domain.repository
+
+import dnd11th.blooming.domain.entity.Image
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ImageRepository : JpaRepository<Image, Long>

--- a/src/main/kotlin/dnd11th/blooming/domain/repository/ImageRepository.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/repository/ImageRepository.kt
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface ImageRepository : JpaRepository<Image, Long> {
     fun findAllByMyPlant(myPlant: MyPlant): List<Image>
+
+    fun deleteAllByMyPlant(myPlant: MyPlant)
 }

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
@@ -67,6 +67,7 @@ class MyPlantControllerTest : DescribeSpec() {
                         MyPlantSaveRequest(
                             scientificName = SCIENTIFIC_NAME,
                             nickname = NICKNAME,
+                            locationId = LOCATION_ID,
                             startDate = START_DATE,
                             lastWateredDate = LAST_WATERED_DATE,
                             lastFertilizerDate = LAST_FERTILIZER_DATE,
@@ -94,6 +95,7 @@ class MyPlantControllerTest : DescribeSpec() {
                         MyPlantSaveRequest(
                             scientificName = SCIENTIFIC_NAME,
                             nickname = NICKNAME,
+                            locationId = LOCATION_ID,
                             startDate = FUTURE_DATE,
                             lastWateredDate = LAST_WATERED_DATE,
                             lastFertilizerDate = LAST_FERTILIZER_DATE,
@@ -121,6 +123,7 @@ class MyPlantControllerTest : DescribeSpec() {
                         MyPlantSaveRequest(
                             scientificName = SCIENTIFIC_NAME,
                             nickname = NICKNAME,
+                            locationId = LOCATION_ID,
                             startDate = START_DATE,
                             lastWateredDate = FUTURE_DATE,
                             lastFertilizerDate = LAST_FERTILIZER_DATE,

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
@@ -2,6 +2,7 @@ package dnd11th.blooming.api.controller.myplant
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
+import dnd11th.blooming.api.dto.image.ImageResponse
 import dnd11th.blooming.api.dto.myplant.AlarmModifyRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantDetailResponse
 import dnd11th.blooming.api.dto.myplant.MyPlantHealthCheckRequest
@@ -225,6 +226,19 @@ class MyPlantControllerTest : DescribeSpec() {
                         fertilizerAlarm = FERTILIZER_ALARM,
                         fertilizerPeriod = FERTILIZER_PERIOD,
                         healthCheckAlarm = HEALTHCHECK_ALARM,
+                        images =
+                            listOf(
+                                ImageResponse(
+                                    imageUrl = "url1",
+                                    favorite = true,
+                                    createdDate = CURRENT_DAY,
+                                ),
+                                ImageResponse(
+                                    imageUrl = "url2",
+                                    favorite = false,
+                                    createdDate = CURRENT_DAY,
+                                ),
+                            ),
                     )
                 every { myPlantService.findMyPlantDetail(ID2, any()) } throws
                     NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
@@ -247,6 +261,9 @@ class MyPlantControllerTest : DescribeSpec() {
                             jsonPath("$.fertilizerAlarm", equalTo(FERTILIZER_ALARM))
                             jsonPath("$.fertilizerPeriod", equalTo(FERTILIZER_PERIOD))
                             jsonPath("$.healthCheckAlarm", equalTo(HEALTHCHECK_ALARM))
+                            jsonPath("$.images.size()", equalTo(2))
+                            jsonPath("$.images[0].imageUrl", equalTo("url1"))
+                            jsonPath("$.images[1].imageUrl", equalTo("url2"))
                         }.andDo { print() }
                 }
             }

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
@@ -291,7 +291,7 @@ class MyPlantControllerTest : DescribeSpec() {
                     myPlantService.modifyMyPlant(
                         any(),
                         match {
-                            it.location != LOCATION_NAME
+                            it.locationId != LOCATION_ID
                         },
                     )
                 } throws
@@ -302,7 +302,7 @@ class MyPlantControllerTest : DescribeSpec() {
                     objectMapper.writeValueAsString(
                         MyPlantModifyRequest(
                             nickname = NICKNAME,
-                            location = LOCATION_NAME,
+                            locationId = LOCATION_ID,
                             startDate = START_DATE,
                             lastWateredDate = LAST_WATERED_DATE,
                             lastFertilizerDate = LAST_FERTILIZER_DATE,
@@ -322,7 +322,7 @@ class MyPlantControllerTest : DescribeSpec() {
                     objectMapper.writeValueAsString(
                         MyPlantModifyRequest(
                             nickname = NICKNAME,
-                            location = LOCATION_NAME,
+                            locationId = LOCATION_ID,
                             startDate = START_DATE,
                             lastWateredDate = LAST_WATERED_DATE,
                             lastFertilizerDate = LAST_FERTILIZER_DATE,
@@ -344,7 +344,7 @@ class MyPlantControllerTest : DescribeSpec() {
                     objectMapper.writeValueAsString(
                         MyPlantModifyRequest(
                             nickname = NICKNAME,
-                            location = "존재하지 않는 장소 이름",
+                            locationId = LOCATION_ID + 1,
                             startDate = START_DATE,
                             lastWateredDate = LAST_WATERED_DATE,
                             lastFertilizerDate = LAST_FERTILIZER_DATE,

--- a/src/test/kotlin/dnd11th/blooming/api/service/home/HomeServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/home/HomeServiceTest.kt
@@ -24,7 +24,7 @@ class HomeServiceTest : DescribeSpec(
                 MyPlant(
                     scientificName = "병아리눈물",
                     nickname = "일번",
-                    createdDate = LocalDate.of(2024, 5, 15),
+                    currentDate = LocalDate.of(2024, 5, 15),
                     lastWateredDate = LocalDate.of(2024, 5, 16),
                     alarm = ALARM,
                 ).apply {
@@ -35,7 +35,7 @@ class HomeServiceTest : DescribeSpec(
                 MyPlant(
                     scientificName = "몬스테라 델리오사",
                     nickname = "이번",
-                    createdDate = LocalDate.of(2024, 5, 16),
+                    currentDate = LocalDate.of(2024, 5, 16),
                     lastWateredDate = LocalDate.of(2024, 5, 17),
                     alarm = ALARM,
                 ).apply {
@@ -46,7 +46,7 @@ class HomeServiceTest : DescribeSpec(
                 MyPlant(
                     scientificName = "선인장",
                     nickname = "삼번",
-                    createdDate = LocalDate.of(2024, 5, 17),
+                    currentDate = LocalDate.of(2024, 5, 17),
                     lastWateredDate = LocalDate.of(2024, 5, 15),
                     alarm = ALARM,
                 ).apply {

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
@@ -46,11 +46,14 @@ class MyPlantServiceTest : DescribeSpec(
                 ).apply {
                     id = PLANT_ID
                 }
+            every { locationRepository.findByIdOrNull(any()) } returns
+                LOCATION1
             context("정상 요청으로 내 식물을 저장하면") {
                 val request =
                     MyPlantSaveRequest(
                         scientificName = SCIENTIFIC_NAME,
                         nickname = NICKNAME,
+                        locationId = LOCATION_ID,
                         startDate = START_DATE,
                         lastWateredDate = LAST_WATERED_DATE,
                         lastFertilizerDate = LAST_FERTILIZER_DATE,
@@ -72,6 +75,7 @@ class MyPlantServiceTest : DescribeSpec(
                     MyPlantSaveRequest(
                         scientificName = SCIENTIFIC_NAME,
                         nickname = NICKNAME,
+                        locationId = LOCATION_ID,
                         startDate = FUTURE_DATE,
                         lastWateredDate = LAST_WATERED_DATE,
                         lastFertilizerDate = LAST_FERTILIZER_DATE,
@@ -95,6 +99,7 @@ class MyPlantServiceTest : DescribeSpec(
                     MyPlantSaveRequest(
                         scientificName = SCIENTIFIC_NAME,
                         nickname = NICKNAME,
+                        locationId = LOCATION_ID,
                         startDate = START_DATE,
                         lastWateredDate = FUTURE_DATE,
                         lastFertilizerDate = LAST_FERTILIZER_DATE,
@@ -118,6 +123,7 @@ class MyPlantServiceTest : DescribeSpec(
                     MyPlantSaveRequest(
                         scientificName = SCIENTIFIC_NAME,
                         nickname = NICKNAME,
+                        locationId = LOCATION_ID,
                         startDate = START_DATE,
                         lastWateredDate = LAST_WATERED_DATE,
                         lastFertilizerDate = FUTURE_DATE,

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
@@ -9,8 +9,10 @@ import dnd11th.blooming.common.exception.ErrorType
 import dnd11th.blooming.common.exception.InvalidDateException
 import dnd11th.blooming.common.exception.NotFoundException
 import dnd11th.blooming.domain.entity.Alarm
+import dnd11th.blooming.domain.entity.Image
 import dnd11th.blooming.domain.entity.Location
 import dnd11th.blooming.domain.entity.MyPlant
+import dnd11th.blooming.domain.repository.ImageRepository
 import dnd11th.blooming.domain.repository.LocationRepository
 import dnd11th.blooming.domain.repository.MyPlantRepository
 import io.kotest.assertions.throwables.shouldNotThrowAny
@@ -28,8 +30,10 @@ class MyPlantServiceTest : DescribeSpec(
     {
         val myPlantRepsitory = mockk<MyPlantRepository>()
         val locationRepository = mockk<LocationRepository>()
+        val imageRepository = mockk<ImageRepository>()
         val myPlantMessageFactory = mockk<MyPlantMessageFactory>()
-        val myPlantService = MyPlantService(myPlantRepsitory, locationRepository, myPlantMessageFactory)
+        val myPlantService =
+            MyPlantService(myPlantRepsitory, locationRepository, myPlantMessageFactory, imageRepository)
 
         describe("내 식물 저장") {
             every { myPlantRepsitory.save(any()) } returns
@@ -266,6 +270,20 @@ class MyPlantServiceTest : DescribeSpec(
                 ).apply {
                     id = PLANT_ID
                 }
+            every { imageRepository.findAllByMyPlant(any()) } returns
+                listOf(
+                    Image(
+                        url = "url1",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ),
+                    Image(
+                        url = "url2",
+                        favorite = false,
+                        currentDate = CURRENT_DAY,
+                    ),
+                )
+
             every { myPlantMessageFactory.createWateredTitle() } returns
                 WATERED_TITLE
             every { myPlantMessageFactory.createWateredInfo(any(), any()) } returns
@@ -286,6 +304,9 @@ class MyPlantServiceTest : DescribeSpec(
                     response.lastWateredInfo shouldBe WATERED_INFO
                     response.lastFertilizerTitle shouldBe FERTILIZER_TITLE
                     response.lastFertilizerInfo shouldBe FERTILIZER_INFO
+                    response.images.size shouldBe 2
+                    response.images[0].imageUrl shouldBe "url1"
+                    response.images[1].imageUrl shouldBe "url2"
                 }
             }
             context("존재하지 않는 ID로 상세 조회하면") {

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
@@ -349,7 +349,7 @@ class MyPlantServiceTest : DescribeSpec(
                 val request =
                     MyPlantModifyRequest(
                         nickname = NICKNAME,
-                        location = LOCATION_NAME,
+                        locationId = LOCATION_ID,
                         startDate = START_DATE,
                         lastWateredDate = LAST_WATERED_DATE,
                         lastFertilizerDate = LAST_FERTILIZER_DATE,
@@ -362,7 +362,7 @@ class MyPlantServiceTest : DescribeSpec(
                 val request =
                     MyPlantModifyRequest(
                         nickname = NICKNAME,
-                        location = LOCATION_NAME,
+                        locationId = LOCATION_ID,
                         startDate = START_DATE,
                         lastWateredDate = LAST_WATERED_DATE,
                         lastFertilizerDate = LAST_FERTILIZER_DATE,
@@ -378,7 +378,7 @@ class MyPlantServiceTest : DescribeSpec(
                 val request =
                     MyPlantModifyRequest(
                         nickname = NICKNAME,
-                        location = LOCATION_NAME2,
+                        locationId = LOCATION_ID + 1,
                         startDate = START_DATE,
                         lastWateredDate = LAST_WATERED_DATE,
                         lastFertilizerDate = LAST_FERTILIZER_DATE,

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
@@ -139,7 +139,7 @@ class MyPlantServiceTest : DescribeSpec(
                 MyPlant(
                     scientificName = "병아리눈물",
                     nickname = "생성1등 물주기2등",
-                    createdDate = LocalDate.of(2024, 5, 15),
+                    currentDate = LocalDate.of(2024, 5, 15),
                     lastWateredDate = LocalDate.of(2024, 5, 16),
                     lastFertilizerDate = LocalDate.of(2024, 5, 16),
                     alarm = ALARM,
@@ -151,7 +151,7 @@ class MyPlantServiceTest : DescribeSpec(
                 MyPlant(
                     scientificName = "몬스테라 델리오사",
                     nickname = "생성2등 물주기3등",
-                    createdDate = LocalDate.of(2024, 5, 16),
+                    currentDate = LocalDate.of(2024, 5, 16),
                     lastWateredDate = LocalDate.of(2024, 5, 17),
                     lastFertilizerDate = LocalDate.of(2024, 5, 17),
                     alarm = ALARM,
@@ -163,7 +163,7 @@ class MyPlantServiceTest : DescribeSpec(
                 MyPlant(
                     scientificName = "선인장",
                     nickname = "생성3등 물주기1등",
-                    createdDate = LocalDate.of(2024, 5, 17),
+                    currentDate = LocalDate.of(2024, 5, 17),
                     lastWateredDate = LocalDate.of(2024, 5, 15),
                     lastFertilizerDate = LocalDate.of(2024, 5, 15),
                     alarm = ALARM,

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
@@ -406,6 +406,7 @@ class MyPlantServiceTest : DescribeSpec(
             every { myPlantRepsitory.findByIdOrNull(not(eq(PLANT_ID))) } returns
                 null
             every { myPlantRepsitory.delete(any()) } just runs
+            every { imageRepository.deleteAllByMyPlant(any()) } just runs
 
             context("정상 요청으로 삭제하면") {
                 it("정상 흐름이 반환되어야 한다.") {

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
@@ -406,7 +406,7 @@ class MyPlantServiceTest : DescribeSpec(
             every { myPlantRepsitory.findByIdOrNull(not(eq(PLANT_ID))) } returns
                 null
             every { myPlantRepsitory.delete(any()) } just runs
-            every { imageRepository.deleteAllByMyPlant(any()) } just runs
+            every { imageRepository.deleteAllInBatchByMyPlant(any()) } just runs
 
             context("정상 요청으로 삭제하면") {
                 it("정상 흐름이 반환되어야 한다.") {


### PR DESCRIPTION
> ### How
- BaseEntity를 작성하고, 다른 모든 엔티티가 상속하도록 하였습니다.
- Image Entity, Repository, Service, Controller를 작성하였습니다.
- 이미지가 필요한 기존 응답들에 이미지 필드를 추가했습니다.
- 기타 연관관계 관련 마이너 수정을 했습니다.

> ### Result
- 이미지 관련
  - 이미지 저장 api를 개발했습니다.
  - 이미지 즐겨찾기 api를 개발했습니다.
  - 이미지 삭제 api를 개발했습니다.
  - 식물상세 api의 응답에 imageUrl 필드를 추가했습니다.
- 연관관계 관련
  - 식물 저장 api의 요청에 장소id를 추가하고, 매핑하도록 수정했습니다.
  - 식물 삭제 api에서, 식물 삭제시 매핑되어있는 이미지도 같이 삭제하도록 수정했습니다.
  - 식물 수정 api의 요청에서 기존에 장소이름을 받았던 것을 장소id를 받도록 수정했습니다.

> ### Prize
- BaseEntity를 통해 해당 엔티티가 생성된 날짜와 마지막으로 수정된 날짜를 추적할 수 있게 되었습니다.
