### PR TITLE
[BLOOM-041] validation 추가, api 마이너 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,11 +34,12 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-	runtimeOnly("com.mysql:mysql-connector-j")
-	runtimeOnly("com.h2database:h2")
+    runtimeOnly("com.mysql:mysql-connector-j")
+    runtimeOnly("com.h2database:h2")
 
-	// Validation
-	implementation("org.springframework.boot:spring-boot-starter-validation")
+    // Validation
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("jakarta.validation:jakarta.validation-api:3.1.0")
 
     // Configuration
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,11 +35,10 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     runtimeOnly("com.mysql:mysql-connector-j")
-    runtimeOnly("com.h2database:h2")
+    testImplementation("com.h2database:h2")
 
     // Validation
     implementation("org.springframework.boot:spring-boot-starter-validation")
-    implementation("jakarta.validation:jakarta.validation-api:3.1.0")
 
     // Configuration
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,8 +34,11 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    runtimeOnly("com.mysql:mysql-connector-j")
-    runtimeOnly("com.h2database:h2")
+	runtimeOnly("com.mysql:mysql-connector-j")
+	runtimeOnly("com.h2database:h2")
+
+	// Validation
+	implementation("org.springframework.boot:spring-boot-starter-validation")
 
     // Configuration
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")

--- a/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
@@ -28,7 +28,10 @@ class ImageController(
     fun modifyFavorite(
         @PathVariable imageId: Long,
         @RequestBody @Valid request: ImageFavoriteModifyRequest,
-    ) = imageService.modifyFavorite(imageId, request)
+    ) {
+        println(">>>" + request.favorite)
+        imageService.modifyFavorite(imageId, request)
+    }
 
     @DeleteMapping("/image/{imageId}")
     fun deleteImage(

--- a/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
@@ -3,6 +3,7 @@ package dnd11th.blooming.api.controller.image
 import dnd11th.blooming.api.dto.image.ImageFavoriteModifyRequest
 import dnd11th.blooming.api.dto.image.ImageSaveRequest
 import dnd11th.blooming.api.service.image.ImageService
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -20,13 +21,13 @@ class ImageController(
     @PostMapping("/{myPlantId}/image")
     fun saveImage(
         @PathVariable myPlantId: Long,
-        @RequestBody request: ImageSaveRequest,
+        @RequestBody @Valid request: ImageSaveRequest,
     ) = imageService.saveImage(myPlantId, request, LocalDate.now())
 
     @PatchMapping("/image/{imageId}")
     fun modifyFavorite(
         @PathVariable imageId: Long,
-        @RequestBody request: ImageFavoriteModifyRequest,
+        @RequestBody @Valid request: ImageFavoriteModifyRequest,
     ) = imageService.modifyFavorite(imageId, request)
 
     @DeleteMapping("/image/{imageId}")

--- a/src/main/kotlin/dnd11th/blooming/api/controller/location/LocationController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/location/LocationController.kt
@@ -5,6 +5,7 @@ import dnd11th.blooming.api.dto.location.LocationResponse
 import dnd11th.blooming.api.dto.location.LocationSaveRequest
 import dnd11th.blooming.api.dto.location.LocationSaveResponse
 import dnd11th.blooming.api.service.location.LocationService
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -21,7 +22,7 @@ class LocationController(
 ) {
     @PostMapping
     fun saveLocation(
-        @RequestBody request: LocationSaveRequest,
+        @RequestBody @Valid request: LocationSaveRequest,
     ): LocationSaveResponse = locationService.saveLocation(request)
 
     @GetMapping
@@ -30,7 +31,7 @@ class LocationController(
     @PatchMapping("/{locationId}")
     fun modifyLocation(
         @PathVariable locationId: Long,
-        @RequestBody request: LocationModifyRequest,
+        @RequestBody @Valid request: LocationModifyRequest,
     ): LocationResponse = locationService.modifyLocation(locationId, request)
 
     @DeleteMapping("/{locationId}")

--- a/src/main/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantController.kt
@@ -31,7 +31,7 @@ class MyPlantController(
     @PostMapping
     fun saveMyPlant(
         @RequestBody @Valid request: MyPlantSaveRequest,
-    ): MyPlantSaveResponse = myPlantService.saveMyPlant(request, LocalDate.now())
+    ): MyPlantSaveResponse = myPlantService.saveMyPlant(request)
 
     @GetMapping
     fun findAllMyPlant(

--- a/src/main/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantController.kt
@@ -31,7 +31,7 @@ class MyPlantController(
     @PostMapping
     fun saveMyPlant(
         @RequestBody @Valid request: MyPlantSaveRequest,
-    ): MyPlantSaveResponse = myPlantService.saveMyPlant(request)
+    ): MyPlantSaveResponse = myPlantService.saveMyPlant(request, LocalDate.now())
 
     @GetMapping
     fun findAllMyPlant(

--- a/src/main/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantController.kt
@@ -11,6 +11,7 @@ import dnd11th.blooming.api.dto.myplant.MyPlantSaveRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantSaveResponse
 import dnd11th.blooming.api.dto.myplant.MyPlantSortParam
 import dnd11th.blooming.api.service.myplant.MyPlantService
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -29,7 +30,7 @@ class MyPlantController(
 ) {
     @PostMapping
     fun saveMyPlant(
-        @RequestBody request: MyPlantSaveRequest,
+        @RequestBody @Valid request: MyPlantSaveRequest,
     ): MyPlantSaveResponse = myPlantService.saveMyPlant(request, LocalDate.now())
 
     @GetMapping
@@ -48,7 +49,7 @@ class MyPlantController(
     @PatchMapping("/{myPlantId}")
     fun modifyMyPlant(
         @PathVariable myPlantId: Long,
-        @RequestBody request: MyPlantModifyRequest,
+        @RequestBody @Valid request: MyPlantModifyRequest,
     ) = myPlantService.modifyMyPlant(myPlantId, request)
 
     @DeleteMapping("/{myPlantId}")
@@ -69,12 +70,12 @@ class MyPlantController(
     @PatchMapping("/{myPlantId}/healthcheck")
     fun modifyMyPlantHealthCheck(
         @PathVariable myPlantId: Long,
-        @RequestBody request: MyPlantHealthCheckRequest,
+        @RequestBody @Valid request: MyPlantHealthCheckRequest,
     ) = myPlantService.modifyMyPlantHealthCheck(myPlantId, request)
 
     @PatchMapping("/{myPlantId}/alarm")
     fun modifyMyPlantAlarm(
         @PathVariable myPlantId: Long,
-        @RequestBody request: AlarmModifyRequest,
+        @RequestBody @Valid request: AlarmModifyRequest,
     ) = myPlantService.modifyMyPlantAlarm(myPlantId, request)
 }

--- a/src/main/kotlin/dnd11th/blooming/api/controller/user/UserController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/user/UserController.kt
@@ -4,6 +4,7 @@ import dnd11th.blooming.api.dto.user.IdTokenRequest
 import dnd11th.blooming.api.dto.user.TokenResponse
 import dnd11th.blooming.api.service.user.SocialLoginService
 import dnd11th.blooming.domain.entity.user.OauthProvider
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -18,7 +19,7 @@ class UserController(
     @PostMapping("/login/{provider}")
     fun login(
         @PathVariable provider: String,
-        @RequestBody idTokenRequest: IdTokenRequest,
+        @RequestBody @Valid idTokenRequest: IdTokenRequest,
     ): TokenResponse {
         return socialLoginService.socialLogin(OauthProvider.from(provider), idTokenRequest.idToken)
     }

--- a/src/main/kotlin/dnd11th/blooming/api/dto/home/HomeResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/home/HomeResponse.kt
@@ -4,6 +4,7 @@ data class HomeResponse(
     val greetingMessage: String,
     val myPlantInfo: List<MyPlantHomeResponse>,
     // TODO : 식물 일러스트 응답 추가 필요
+    // val illustUrl: String,
 ) {
     companion object {
         fun from(

--- a/src/main/kotlin/dnd11th/blooming/api/dto/home/MyPlantHomeResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/home/MyPlantHomeResponse.kt
@@ -4,7 +4,7 @@ import dnd11th.blooming.domain.entity.MyPlant
 import java.time.LocalDate
 
 data class MyPlantHomeResponse(
-    val myPlantId: Long,
+    val myPlantId: Long?,
     val nickname: String,
     val scientificName: String,
     val waterAlarm: Boolean,

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageFavoriteModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageFavoriteModifyRequest.kt
@@ -1,5 +1,8 @@
 package dnd11th.blooming.api.dto.image
 
+import jakarta.validation.constraints.NotNull
+
 data class ImageFavoriteModifyRequest(
+    @NotNull(message = "즐겨찾기 여부는 필수값입니다.")
     val favorite: Boolean,
 )

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageFavoriteModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageFavoriteModifyRequest.kt
@@ -1,13 +1,8 @@
 package dnd11th.blooming.api.dto.image
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotNull
 
 data class ImageFavoriteModifyRequest(
     @field:NotNull(message = "즐겨찾기 여부는 필수값입니다.")
-    @JsonProperty("favorite")
-    private val _favorite: Boolean?,
-) {
-    val favorite: Boolean
-        get() = _favorite!!
-}
+    val favorite: Boolean?,
+)

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageFavoriteModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageFavoriteModifyRequest.kt
@@ -1,8 +1,13 @@
 package dnd11th.blooming.api.dto.image
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotNull
 
 data class ImageFavoriteModifyRequest(
     @field:NotNull(message = "즐겨찾기 여부는 필수값입니다.")
-    val favorite: Boolean,
-)
+    @JsonProperty("favorite")
+    private val _favorite: Boolean?,
+) {
+    val favorite: Boolean
+        get() = _favorite!!
+}

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageFavoriteModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageFavoriteModifyRequest.kt
@@ -3,6 +3,6 @@ package dnd11th.blooming.api.dto.image
 import jakarta.validation.constraints.NotNull
 
 data class ImageFavoriteModifyRequest(
-    @NotNull(message = "즐겨찾기 여부는 필수값입니다.")
+    @field:NotNull(message = "즐겨찾기 여부는 필수값입니다.")
     val favorite: Boolean,
 )

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageSaveRequest.kt
@@ -3,12 +3,10 @@ package dnd11th.blooming.api.dto.image
 import dnd11th.blooming.domain.entity.Image
 import dnd11th.blooming.domain.entity.MyPlant
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
 import java.time.LocalDate
 
 data class ImageSaveRequest(
-    @field:NotNull(message = "URL은 필수값입니다.")
-    @field:NotBlank(message = "URL은 비어있을 수 없습니다.")
+    @field:NotBlank(message = "URL은 필수값입니다.")
     val imageUrl: String?,
 ) {
     fun toImage(

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageSaveRequest.kt
@@ -7,19 +7,19 @@ import jakarta.validation.constraints.NotNull
 import java.time.LocalDate
 
 data class ImageSaveRequest(
-	@NotNull(message = "URL은 필수값입니다.")
-	@NotBlank(message = "URL은 비어있을 수 없습니다.")
+    @field:NotNull(message = "URL은 필수값입니다.")
+    @field:NotBlank(message = "URL은 비어있을 수 없습니다.")
     val imageUrl: String,
 ) {
-	fun toImage(
-		myPlant: MyPlant,
-		now: LocalDate,
-	): Image =
-		Image(
-			url = imageUrl,
-			favorite = false,
-			currentDate = now,
-		).also {
-			it.setMyPlantRelation(myPlant)
-		}
+    fun toImage(
+        myPlant: MyPlant,
+        now: LocalDate,
+    ): Image =
+        Image(
+            url = imageUrl,
+            favorite = false,
+            currentDate = now,
+        ).also {
+            it.setMyPlantRelation(myPlant)
+        }
 }

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageSaveRequest.kt
@@ -9,14 +9,14 @@ import java.time.LocalDate
 data class ImageSaveRequest(
     @field:NotNull(message = "URL은 필수값입니다.")
     @field:NotBlank(message = "URL은 비어있을 수 없습니다.")
-    val imageUrl: String,
+    val imageUrl: String?,
 ) {
     fun toImage(
         myPlant: MyPlant,
         now: LocalDate,
     ): Image =
         Image(
-            url = imageUrl,
+            url = imageUrl!!,
             favorite = false,
             currentDate = now,
         ).also {

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageSaveRequest.kt
@@ -2,20 +2,24 @@ package dnd11th.blooming.api.dto.image
 
 import dnd11th.blooming.domain.entity.Image
 import dnd11th.blooming.domain.entity.MyPlant
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 import java.time.LocalDate
 
 data class ImageSaveRequest(
+	@NotNull(message = "URL은 필수값입니다.")
+	@NotBlank(message = "URL은 비어있을 수 없습니다.")
     val imageUrl: String,
 ) {
-    fun toImage(
-        myPlant: MyPlant,
-        now: LocalDate,
-    ): Image =
-        Image(
-            url = imageUrl,
-            favorite = false,
-            currentDate = now,
-        ).also {
-            it.setMyPlantRelation(myPlant)
-        }
+	fun toImage(
+		myPlant: MyPlant,
+		now: LocalDate,
+	): Image =
+		Image(
+			url = imageUrl,
+			favorite = false,
+			currentDate = now,
+		).also {
+			it.setMyPlantRelation(myPlant)
+		}
 }

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationModifyRequest.kt
@@ -1,15 +1,8 @@
 package dnd11th.blooming.api.dto.location
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
 
 data class LocationModifyRequest(
-    @field:NotNull(message = "새로운 위치명은 필수값입니다.")
-    @field:NotBlank(message = "새로운 위치명은 비어있을 수 없습니다.")
-    @JsonProperty("name")
-    private val _name: String?,
-) {
-    val name: String
-        get() = _name!!
-}
+    @field:NotBlank(message = "새로운 위치명은 필수값입니다.")
+    val name: String?,
+)

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationModifyRequest.kt
@@ -1,10 +1,15 @@
 package dnd11th.blooming.api.dto.location
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 
 data class LocationModifyRequest(
     @field:NotNull(message = "새로운 위치명은 필수값입니다.")
     @field:NotBlank(message = "새로운 위치명은 비어있을 수 없습니다.")
-    val name: String,
-)
+    @JsonProperty("name")
+    private val _name: String?,
+) {
+    val name: String
+        get() = _name!!
+}

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationModifyRequest.kt
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 
 data class LocationModifyRequest(
-    @NotNull(message = "새로운 위치명은 필수값입니다.")
-    @NotBlank(message = "새로운 위치명은 비어있을 수 없습니다.")
+    @field:NotNull(message = "새로운 위치명은 필수값입니다.")
+    @field:NotBlank(message = "새로운 위치명은 비어있을 수 없습니다.")
     val name: String,
 )

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationModifyRequest.kt
@@ -1,5 +1,10 @@
 package dnd11th.blooming.api.dto.location
 
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
 data class LocationModifyRequest(
+    @NotNull(message = "새로운 위치명은 필수값입니다.")
+    @NotBlank(message = "새로운 위치명은 비어있을 수 없습니다.")
     val name: String,
 )

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationResponse.kt
@@ -3,7 +3,7 @@ package dnd11th.blooming.api.dto.location
 import dnd11th.blooming.domain.entity.Location
 
 data class LocationResponse(
-    val id: Long,
+    val id: Long?,
     val name: String,
 ) {
     companion object {

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveRequest.kt
@@ -1,8 +1,12 @@
 package dnd11th.blooming.api.dto.location
 
 import dnd11th.blooming.domain.entity.Location
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 
 data class LocationSaveRequest(
+    @NotNull(message = "새로운 위치명은 필수값입니다.")
+    @NotBlank(message = "새로운 위치명은 비어있을 수 없습니다.")
     val name: String,
 ) {
     fun toLocation(): Location =

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveRequest.kt
@@ -2,11 +2,9 @@ package dnd11th.blooming.api.dto.location
 
 import dnd11th.blooming.domain.entity.Location
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
 
 data class LocationSaveRequest(
-    @field:NotNull(message = "새로운 위치명은 필수값입니다.")
-    @field:NotBlank(message = "새로운 위치명은 비어있을 수 없습니다.")
+    @field:NotBlank(message = "새로운 위치명은 필수값입니다.")
     val name: String?,
 ) {
     fun toLocation(): Location =

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveRequest.kt
@@ -5,8 +5,8 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 
 data class LocationSaveRequest(
-    @NotNull(message = "새로운 위치명은 필수값입니다.")
-    @NotBlank(message = "새로운 위치명은 비어있을 수 없습니다.")
+    @field:NotNull(message = "새로운 위치명은 필수값입니다.")
+    @field:NotBlank(message = "새로운 위치명은 비어있을 수 없습니다.")
     val name: String,
 ) {
     fun toLocation(): Location =

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveRequest.kt
@@ -7,10 +7,10 @@ import jakarta.validation.constraints.NotNull
 data class LocationSaveRequest(
     @field:NotNull(message = "새로운 위치명은 필수값입니다.")
     @field:NotBlank(message = "새로운 위치명은 비어있을 수 없습니다.")
-    val name: String,
+    val name: String?,
 ) {
     fun toLocation(): Location =
         Location(
-            name = name,
+            name = name!!,
         )
 }

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveResponse.kt
@@ -3,7 +3,7 @@ package dnd11th.blooming.api.dto.location
 import dnd11th.blooming.domain.entity.Location
 
 class LocationSaveResponse(
-    val id: Long,
+    val id: Long?,
     val name: String,
 ) {
     companion object {

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/AlarmModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/AlarmModifyRequest.kt
@@ -4,13 +4,13 @@ import dnd11th.blooming.domain.entity.Alarm
 import jakarta.validation.constraints.NotNull
 
 data class AlarmModifyRequest(
-    @NotNull(message = "물주기 알림 여부는 필수값입니다.")
+    @field:NotNull(message = "물주기 알림 여부는 필수값입니다.")
     val waterAlarm: Boolean,
     val waterPeriod: Int?,
-    @NotNull(message = "비료주기 알림 여부는 필수값입니다.")
+    @field:NotNull(message = "비료주기 알림 여부는 필수값입니다.")
     val fertilizerAlarm: Boolean,
     val fertilizerPeriod: Int?,
-    @NotNull(message = "건강확인 알림 여부는 필수값입니다.")
+    @field:NotNull(message = "건강확인 알림 여부는 필수값입니다.")
     val healthCheckAlarm: Boolean,
 ) {
     fun toAlarm(): Alarm =

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/AlarmModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/AlarmModifyRequest.kt
@@ -1,12 +1,16 @@
 package dnd11th.blooming.api.dto.myplant
 
 import dnd11th.blooming.domain.entity.Alarm
+import jakarta.validation.constraints.NotNull
 
 data class AlarmModifyRequest(
+    @NotNull(message = "물주기 알림 여부는 필수값입니다.")
     val waterAlarm: Boolean,
     val waterPeriod: Int?,
+    @NotNull(message = "비료주기 알림 여부는 필수값입니다.")
     val fertilizerAlarm: Boolean,
     val fertilizerPeriod: Int?,
+    @NotNull(message = "건강확인 알림 여부는 필수값입니다.")
     val healthCheckAlarm: Boolean,
 ) {
     fun toAlarm(): Alarm =

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/AlarmModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/AlarmModifyRequest.kt
@@ -5,20 +5,20 @@ import jakarta.validation.constraints.NotNull
 
 data class AlarmModifyRequest(
     @field:NotNull(message = "물주기 알림 여부는 필수값입니다.")
-    val waterAlarm: Boolean,
+    val waterAlarm: Boolean?,
     val waterPeriod: Int?,
     @field:NotNull(message = "비료주기 알림 여부는 필수값입니다.")
-    val fertilizerAlarm: Boolean,
+    val fertilizerAlarm: Boolean?,
     val fertilizerPeriod: Int?,
     @field:NotNull(message = "건강확인 알림 여부는 필수값입니다.")
-    val healthCheckAlarm: Boolean,
+    val healthCheckAlarm: Boolean?,
 ) {
     fun toAlarm(): Alarm =
         Alarm(
-            waterAlarm = waterAlarm,
+            waterAlarm = waterAlarm!!,
             waterPeriod = waterPeriod,
-            fertilizerAlarm = fertilizerAlarm,
+            fertilizerAlarm = fertilizerAlarm!!,
             fertilizerPeriod = fertilizerPeriod,
-            healthCheckAlarm = healthCheckAlarm,
+            healthCheckAlarm = healthCheckAlarm!!,
         )
 }

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantHealthCheckRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantHealthCheckRequest.kt
@@ -3,6 +3,6 @@ package dnd11th.blooming.api.dto.myplant
 import jakarta.validation.constraints.NotNull
 
 data class MyPlantHealthCheckRequest(
-    @NotNull(message = "건강확인 알림 여부는 필수값입니다.")
+    @field:NotNull(message = "건강확인 알림 여부는 필수값입니다.")
     val healthCheck: Boolean,
 )

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantHealthCheckRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantHealthCheckRequest.kt
@@ -1,8 +1,13 @@
 package dnd11th.blooming.api.dto.myplant
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotNull
 
 data class MyPlantHealthCheckRequest(
     @field:NotNull(message = "건강확인 알림 여부는 필수값입니다.")
-    val healthCheck: Boolean,
-)
+    @JsonProperty("healthCheck")
+    private val _healthCheck: Boolean?,
+) {
+    val healthCheck: Boolean
+        get() = _healthCheck!!
+}

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantHealthCheckRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantHealthCheckRequest.kt
@@ -1,5 +1,8 @@
 package dnd11th.blooming.api.dto.myplant
 
+import jakarta.validation.constraints.NotNull
+
 data class MyPlantHealthCheckRequest(
+    @NotNull(message = "건강확인 알림 여부는 필수값입니다.")
     val healthCheck: Boolean,
 )

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantHealthCheckRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantHealthCheckRequest.kt
@@ -1,13 +1,8 @@
 package dnd11th.blooming.api.dto.myplant
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotNull
 
 data class MyPlantHealthCheckRequest(
     @field:NotNull(message = "건강확인 알림 여부는 필수값입니다.")
-    @JsonProperty("healthCheck")
-    private val _healthCheck: Boolean?,
-) {
-    val healthCheck: Boolean
-        get() = _healthCheck!!
-}
+    val healthCheck: Boolean?,
+)

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantIdWithImageUrl.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantIdWithImageUrl.kt
@@ -1,0 +1,6 @@
+package dnd11th.blooming.api.dto.myplant
+
+data class MyPlantIdWithImageUrl(
+    val imageUrl: String,
+    val myPlantId: Long,
+)

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantModifyRequest.kt
@@ -1,11 +1,9 @@
 package dnd11th.blooming.api.dto.myplant
 
-import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.PastOrPresent
 import java.time.LocalDate
 
 data class MyPlantModifyRequest(
-    @field:NotBlank(message = "식물 별명은 비어있을 수 없습니다.")
     val nickname: String?,
     val locationId: Long?,
     @field:PastOrPresent(message = "키우기 시작한 날짜는 미래일 수 없습니다.")

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantModifyRequest.kt
@@ -1,11 +1,17 @@
 package dnd11th.blooming.api.dto.myplant
 
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.PastOrPresent
 import java.time.LocalDate
 
 data class MyPlantModifyRequest(
+    @field:NotBlank(message = "식물 별명은 비어있을 수 없습니다.")
     val nickname: String?,
     val locationId: Long?,
+    @field:PastOrPresent(message = "키우기 시작한 날짜는 미래일 수 없습니다.")
     val startDate: LocalDate?,
+    @field:PastOrPresent(message = "마지막으로 물 준 날짜는 미래일 수 없습니다.")
     val lastWateredDate: LocalDate?,
+    @field:PastOrPresent(message = "마지막으로 비료 준 날짜는 미래일 수 없습니다.")
     val lastFertilizerDate: LocalDate?,
 )

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantResponse.kt
@@ -6,6 +6,7 @@ import java.time.LocalDate
 data class MyPlantResponse(
     val myPlantId: Long?,
     val nickname: String,
+    val imageUrl: String,
     val scientificName: String,
     val waterRemainDay: Int?,
     val fertilizerRemainDay: Int?,
@@ -13,11 +14,13 @@ data class MyPlantResponse(
     companion object {
         fun of(
             myPlant: MyPlant,
+            imageUrl: String,
             now: LocalDate,
         ): MyPlantResponse =
             MyPlantResponse(
                 myPlantId = myPlant.id,
                 nickname = myPlant.nickname,
+                imageUrl = imageUrl,
                 scientificName = myPlant.scientificName,
                 waterRemainDay = myPlant.getWaterRemainDay(now),
                 fertilizerRemainDay = myPlant.getFerilizerRemainDate(now),

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantResponse.kt
@@ -4,7 +4,7 @@ import dnd11th.blooming.domain.entity.MyPlant
 import java.time.LocalDate
 
 data class MyPlantResponse(
-    val myPlantId: Long,
+    val myPlantId: Long?,
     val nickname: String,
     val scientificName: String,
     val waterRemainDay: Int?,

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
@@ -12,8 +12,7 @@ data class MyPlantSaveRequest(
     // TODO : 식물 종류를 String이 아니라 plantId로 받기
     @field:NotNull(message = "식물 종류는 필수값입니다.")
     val plantId: Long?,
-    @field:NotNull(message = "식물 별명은 필수값입니다.")
-    @field:NotBlank(message = "식물 별명은 비어있을 수 없습니다.")
+    @field:NotBlank(message = "식물 별명은 필수값입니다.")
     val nickname: String?,
     @field:NotNull(message = "위치는 필수값입니다.")
     val locationId: Long?,

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
@@ -1,6 +1,7 @@
 package dnd11th.blooming.api.dto.myplant
 
 import dnd11th.blooming.domain.entity.Alarm
+import dnd11th.blooming.domain.entity.Location
 import dnd11th.blooming.domain.entity.MyPlant
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
@@ -32,13 +33,18 @@ data class MyPlantSaveRequest(
     @field:NotNull(message = "건강확인 알림 여부는 필수값입니다.")
     val healthCheckAlarm: Boolean,
 ) {
-    fun toMyPlant(scientificName: String): MyPlant =
+    fun toMyPlant(
+        location: Location,
+        now: LocalDate,
+        scientificName: String,
+    ): MyPlant =
         MyPlant(
             scientificName = scientificName,
             nickname = nickname,
             startDate = startDate,
             lastWateredDate = lastWateredDate,
             lastFertilizerDate = lastFertilizerDate,
+            currentDate = now,
             alarm =
                 Alarm(
                     waterAlarm = waterAlarm,
@@ -47,5 +53,7 @@ data class MyPlantSaveRequest(
                     fertilizerPeriod = fertilizerPeriod,
                     healthCheckAlarm = healthCheckAlarm,
                 ),
-        )
+        ).also {
+            it.setLocationRelation(location)
+        }
 }

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
@@ -5,6 +5,7 @@ import dnd11th.blooming.domain.entity.Location
 import dnd11th.blooming.domain.entity.MyPlant
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.PastOrPresent
 import java.time.LocalDate
 
 data class MyPlantSaveRequest(
@@ -12,12 +13,16 @@ data class MyPlantSaveRequest(
     @field:NotNull(message = "식물 종류는 필수값입니다.")
     @field:NotBlank(message = "식물 종류는 비어있을 수 없습니다.")
     val scientificName: String,
+    @field:NotBlank(message = "식물 별명은 비어있을 수 없습니다.")
     val nickname: String = scientificName,
     @field:NotNull(message = "위치는 필수값입니다.")
     val locationId: Long,
     // TODO : 키우기 시작한 날짜, 마지막으로 물 준 날짜, 마지막으로 비료 준 날짜 optional로 만들기
+    @field:PastOrPresent(message = "키우기 시작한 날짜는 미래일 수 없습니다.")
     val startDate: LocalDate,
+    @field:PastOrPresent(message = "마지막으로 물 준 날짜는 미래일 수 없습니다.")
     val lastWateredDate: LocalDate,
+    @field:PastOrPresent(message = "마지막으로 비료 준 날짜는 미래일 수 없습니다.")
     val lastFertilizerDate: LocalDate,
     @field:NotNull(message = "물주기 알림 여부는 필수값입니다.")
     val waterAlarm: Boolean,

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
@@ -11,6 +11,7 @@ data class MyPlantSaveRequest(
     // TODO : 식물 종류를 String이 아니라 plantId로 받기
     @field:NotNull(message = "식물 종류는 필수값입니다.")
     val plantId: Long,
+    @field:NotNull(message = "식물 별명은 필수값입니다.")
     @field:NotBlank(message = "식물 별명은 비어있을 수 없습니다.")
     val nickname: String,
     @field:NotNull(message = "위치는 필수값입니다.")

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
@@ -3,19 +3,29 @@ package dnd11th.blooming.api.dto.myplant
 import dnd11th.blooming.domain.entity.Alarm
 import dnd11th.blooming.domain.entity.Location
 import dnd11th.blooming.domain.entity.MyPlant
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 import java.time.LocalDate
 
 data class MyPlantSaveRequest(
+    // TODO : 식물 종류를 String이 아니라 plantId로 받기
+    @NotNull(message = "식물 종류는 필수값입니다.")
+    @NotBlank(message = "식물 종류는 비어있을 수 없습니다.")
     val scientificName: String,
-    val nickname: String,
+    val nickname: String = scientificName,
+    @NotNull(message = "위치는 필수값입니다.")
     val locationId: Long,
+    // TODO : 키우기 시작한 날짜, 마지막으로 물 준 날짜, 마지막으로 비료 준 날짜 optional로 만들기
     val startDate: LocalDate,
     val lastWateredDate: LocalDate,
     val lastFertilizerDate: LocalDate,
+    @NotNull(message = "물주기 알림 여부는 필수값입니다.")
     val waterAlarm: Boolean,
     val waterPeriod: Int?,
+    @NotNull(message = "비료주기 알림 여부는 필수값입니다.")
     val fertilizerAlarm: Boolean,
     val fertilizerPeriod: Int?,
+    @NotNull(message = "건강확인 알림 여부는 필수값입니다.")
     val healthCheckAlarm: Boolean,
 ) {
     fun toMyPlant(

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
@@ -9,23 +9,23 @@ import java.time.LocalDate
 
 data class MyPlantSaveRequest(
     // TODO : 식물 종류를 String이 아니라 plantId로 받기
-    @NotNull(message = "식물 종류는 필수값입니다.")
-    @NotBlank(message = "식물 종류는 비어있을 수 없습니다.")
+    @field:NotNull(message = "식물 종류는 필수값입니다.")
+    @field:NotBlank(message = "식물 종류는 비어있을 수 없습니다.")
     val scientificName: String,
     val nickname: String = scientificName,
-    @NotNull(message = "위치는 필수값입니다.")
+    @field:NotNull(message = "위치는 필수값입니다.")
     val locationId: Long,
     // TODO : 키우기 시작한 날짜, 마지막으로 물 준 날짜, 마지막으로 비료 준 날짜 optional로 만들기
     val startDate: LocalDate,
     val lastWateredDate: LocalDate,
     val lastFertilizerDate: LocalDate,
-    @NotNull(message = "물주기 알림 여부는 필수값입니다.")
+    @field:NotNull(message = "물주기 알림 여부는 필수값입니다.")
     val waterAlarm: Boolean,
     val waterPeriod: Int?,
-    @NotNull(message = "비료주기 알림 여부는 필수값입니다.")
+    @field:NotNull(message = "비료주기 알림 여부는 필수값입니다.")
     val fertilizerAlarm: Boolean,
     val fertilizerPeriod: Int?,
-    @NotNull(message = "건강확인 알림 여부는 필수값입니다.")
+    @field:NotNull(message = "건강확인 알림 여부는 필수값입니다.")
     val healthCheckAlarm: Boolean,
 ) {
     fun toMyPlant(

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
@@ -11,12 +11,12 @@ import java.time.LocalDate
 data class MyPlantSaveRequest(
     // TODO : 식물 종류를 String이 아니라 plantId로 받기
     @field:NotNull(message = "식물 종류는 필수값입니다.")
-    val plantId: Long,
+    val plantId: Long?,
     @field:NotNull(message = "식물 별명은 필수값입니다.")
     @field:NotBlank(message = "식물 별명은 비어있을 수 없습니다.")
-    val nickname: String,
+    val nickname: String?,
     @field:NotNull(message = "위치는 필수값입니다.")
-    val locationId: Long,
+    val locationId: Long?,
     // TODO : 키우기 시작한 날짜, 마지막으로 물 준 날짜, 마지막으로 비료 준 날짜 optional로 만들기
     @field:PastOrPresent(message = "키우기 시작한 날짜는 미래일 수 없습니다.")
     val startDate: LocalDate,
@@ -25,13 +25,13 @@ data class MyPlantSaveRequest(
     @field:PastOrPresent(message = "마지막으로 비료 준 날짜는 미래일 수 없습니다.")
     val lastFertilizerDate: LocalDate,
     @field:NotNull(message = "물주기 알림 여부는 필수값입니다.")
-    val waterAlarm: Boolean,
+    val waterAlarm: Boolean?,
     val waterPeriod: Int?,
     @field:NotNull(message = "비료주기 알림 여부는 필수값입니다.")
-    val fertilizerAlarm: Boolean,
+    val fertilizerAlarm: Boolean?,
     val fertilizerPeriod: Int?,
     @field:NotNull(message = "건강확인 알림 여부는 필수값입니다.")
-    val healthCheckAlarm: Boolean,
+    val healthCheckAlarm: Boolean?,
 ) {
     fun toMyPlant(
         location: Location,
@@ -40,18 +40,18 @@ data class MyPlantSaveRequest(
     ): MyPlant =
         MyPlant(
             scientificName = scientificName,
-            nickname = nickname,
+            nickname = nickname!!,
             startDate = startDate,
             lastWateredDate = lastWateredDate,
             lastFertilizerDate = lastFertilizerDate,
             currentDate = now,
             alarm =
                 Alarm(
-                    waterAlarm = waterAlarm,
+                    waterAlarm = waterAlarm!!,
                     waterPeriod = waterPeriod,
-                    fertilizerAlarm = fertilizerAlarm,
+                    fertilizerAlarm = fertilizerAlarm!!,
                     fertilizerPeriod = fertilizerPeriod,
-                    healthCheckAlarm = healthCheckAlarm,
+                    healthCheckAlarm = healthCheckAlarm!!,
                 ),
         ).also {
             it.setLocationRelation(location)

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
@@ -1,7 +1,6 @@
 package dnd11th.blooming.api.dto.myplant
 
 import dnd11th.blooming.domain.entity.Alarm
-import dnd11th.blooming.domain.entity.Location
 import dnd11th.blooming.domain.entity.MyPlant
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
@@ -11,10 +10,9 @@ import java.time.LocalDate
 data class MyPlantSaveRequest(
     // TODO : 식물 종류를 String이 아니라 plantId로 받기
     @field:NotNull(message = "식물 종류는 필수값입니다.")
-    @field:NotBlank(message = "식물 종류는 비어있을 수 없습니다.")
-    val scientificName: String,
+    val plantId: Long,
     @field:NotBlank(message = "식물 별명은 비어있을 수 없습니다.")
-    val nickname: String = scientificName,
+    val nickname: String,
     @field:NotNull(message = "위치는 필수값입니다.")
     val locationId: Long,
     // TODO : 키우기 시작한 날짜, 마지막으로 물 준 날짜, 마지막으로 비료 준 날짜 optional로 만들기
@@ -33,17 +31,13 @@ data class MyPlantSaveRequest(
     @field:NotNull(message = "건강확인 알림 여부는 필수값입니다.")
     val healthCheckAlarm: Boolean,
 ) {
-    fun toMyPlant(
-        location: Location,
-        now: LocalDate,
-    ): MyPlant =
+    fun toMyPlant(scientificName: String): MyPlant =
         MyPlant(
             scientificName = scientificName,
             nickname = nickname,
             startDate = startDate,
             lastWateredDate = lastWateredDate,
             lastFertilizerDate = lastFertilizerDate,
-            currentDate = now,
             alarm =
                 Alarm(
                     waterAlarm = waterAlarm,
@@ -52,9 +46,5 @@ data class MyPlantSaveRequest(
                     fertilizerPeriod = fertilizerPeriod,
                     healthCheckAlarm = healthCheckAlarm,
                 ),
-        ).also {
-            it.setLocationRelation(location)
-            // TODO : 유저와 매핑 필요
-            // TODO : 식물가이드와 매핑 필요
-        }
+        )
 }

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveResponse.kt
@@ -3,7 +3,7 @@ package dnd11th.blooming.api.dto.myplant
 import dnd11th.blooming.domain.entity.MyPlant
 
 data class MyPlantSaveResponse(
-    val myPlantId: Long,
+    val myPlantId: Long?,
 ) {
     val message: String = "등록 되었습니다."
 

--- a/src/main/kotlin/dnd11th/blooming/api/dto/user/IdTokenRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/user/IdTokenRequest.kt
@@ -3,6 +3,6 @@ package dnd11th.blooming.api.dto.user
 import jakarta.validation.constraints.NotNull
 
 data class IdTokenRequest(
-    @NotNull(message = "idToken은 필수값입니다.")
+    @field:NotNull(message = "idToken은 필수값입니다.")
     val idToken: String,
 )

--- a/src/main/kotlin/dnd11th/blooming/api/dto/user/IdTokenRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/user/IdTokenRequest.kt
@@ -1,8 +1,8 @@
 package dnd11th.blooming.api.dto.user
 
-import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.NotBlank
 
 data class IdTokenRequest(
-    @field:NotNull(message = "idToken은 필수값입니다.")
+    @field:NotBlank(message = "idToken은 필수값입니다.")
     val idToken: String,
 )

--- a/src/main/kotlin/dnd11th/blooming/api/dto/user/IdTokenRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/user/IdTokenRequest.kt
@@ -1,5 +1,8 @@
 package dnd11th.blooming.api.dto.user
 
+import jakarta.validation.constraints.NotNull
+
 data class IdTokenRequest(
+    @NotNull(message = "idToken은 필수값입니다.")
     val idToken: String,
 )

--- a/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
@@ -40,7 +40,7 @@ class ImageService(
             imageRepository.findByIdOrNull(imageId)
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_IMAGE)
 
-        image.modifyFavorite(request.favorite)
+        image.modifyFavorite(request.favorite!!)
     }
 
     @Transactional

--- a/src/main/kotlin/dnd11th/blooming/api/service/location/LocationService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/location/LocationService.kt
@@ -37,7 +37,7 @@ class LocationService(
             locationRepository.findByIdOrNull(locationId)
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_LOCATION)
 
-        location.modifyName(request.name)
+        location.modifyName(request.name!!)
 
         return LocationResponse.from(location)
     }

--- a/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
@@ -9,7 +9,6 @@ import dnd11th.blooming.api.dto.myplant.MyPlantResponse
 import dnd11th.blooming.api.dto.myplant.MyPlantSaveRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantSaveResponse
 import dnd11th.blooming.common.exception.ErrorType
-import dnd11th.blooming.common.exception.InvalidDateException
 import dnd11th.blooming.common.exception.NotFoundException
 import dnd11th.blooming.domain.entity.MyPlant
 import dnd11th.blooming.domain.repository.ImageRepository
@@ -28,14 +27,7 @@ class MyPlantService(
     private val imageRepository: ImageRepository,
 ) {
     @Transactional
-    fun saveMyPlant(
-        request: MyPlantSaveRequest,
-        now: LocalDate,
-    ): MyPlantSaveResponse {
-        validateDateNotInFuture(request.startDate, now)
-        validateDateNotInFuture(request.lastWateredDate, now)
-        validateDateNotInFuture(request.lastFertilizerDate, now)
-
+    fun saveMyPlant(request: MyPlantSaveRequest): MyPlantSaveResponse {
         val location =
             locationRepository
                 .findByIdOrNull(request.locationId)
@@ -153,15 +145,6 @@ class MyPlantService(
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
 
         myPlant.modifyHealthCheck(request.healthCheck)
-    }
-
-    private fun validateDateNotInFuture(
-        targetDate: LocalDate,
-        currentDate: LocalDate,
-    ) {
-        if (targetDate.isAfter(currentDate)) {
-            throw InvalidDateException(ErrorType.INVALID_DATE)
-        }
     }
 
     private fun findSortedMyPlants(

--- a/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
@@ -154,7 +154,7 @@ class MyPlantService(
             myPlantRepository.findByIdOrNull(myPlantId)
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
 
-        myPlant.modifyHealthCheck(request.healthCheck)
+        myPlant.modifyHealthCheck(request.healthCheck!!)
     }
 
     private fun findSortedMyPlantsWithImage(

--- a/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
@@ -27,13 +27,19 @@ class MyPlantService(
     private val imageRepository: ImageRepository,
 ) {
     @Transactional
-    fun saveMyPlant(request: MyPlantSaveRequest): MyPlantSaveResponse {
+    fun saveMyPlant(
+        request: MyPlantSaveRequest,
+        now: LocalDate,
+    ): MyPlantSaveResponse {
         val location =
             locationRepository
                 .findByIdOrNull(request.locationId)
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_LOCATION)
 
-        val myPlant = request.toMyPlant(location, now)
+        // TODO : 식물 가이드 데이터 가져오기 필요
+        val scientificName = "몬스테라 델리오사"
+
+        val myPlant = request.toMyPlant(location, now, scientificName)
 
         val savedPlant = myPlantRepository.save(myPlant)
 

--- a/src/main/kotlin/dnd11th/blooming/common/exception/ErrorResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/exception/ErrorResponse.kt
@@ -6,12 +6,12 @@ import com.fasterxml.jackson.annotation.JsonInclude
 data class ErrorResponse private constructor(
     val code: ErrorType,
     val message: String,
-    val fields: Map<String, String>?,
+    val fields: List<FieldErrorResponse>?,
 ) {
     companion object {
         fun from(
             errorType: ErrorType,
-            fields: Map<String, String>? = null,
+            fields: List<FieldErrorResponse>? = null,
         ): ErrorResponse =
             ErrorResponse(
                 code = errorType,

--- a/src/main/kotlin/dnd11th/blooming/common/exception/ErrorResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/exception/ErrorResponse.kt
@@ -6,17 +6,17 @@ import com.fasterxml.jackson.annotation.JsonInclude
 data class ErrorResponse private constructor(
     val code: ErrorType,
     val message: String,
-    val field: List<String>?,
+    val fields: Map<String, String>?,
 ) {
     companion object {
         fun from(
             errorType: ErrorType,
-            field: List<String>? = null,
+            fields: Map<String, String>? = null,
         ): ErrorResponse =
             ErrorResponse(
                 code = errorType,
                 message = errorType.message,
-                field = field,
+                fields = fields,
             )
     }
 }

--- a/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
@@ -6,7 +6,6 @@ import org.springframework.http.HttpStatus
 enum class ErrorType(val status: HttpStatus, var message: String, val logLevel: LogLevel) {
     // COMMON
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error has occurred.", LogLevel.ERROR),
-    INVALID_DATE(HttpStatus.BAD_REQUEST, "올바르지 않은 날짜입니다.", LogLevel.DEBUG),
     ARGUMENT_ERROR(HttpStatus.BAD_REQUEST, "올바르지 않은 요청이 포함되었습니다.", LogLevel.DEBUG),
 
     // MyPlant

--- a/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus
 enum class ErrorType(val status: HttpStatus, var message: String, val logLevel: LogLevel) {
     // COMMON
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error has occurred.", LogLevel.ERROR),
-    ARGUMENT_ERROR(HttpStatus.BAD_REQUEST, "올바르지 않은 요청이 포함되었습니다.", LogLevel.DEBUG),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "올바르지 않은 요청이 포함되었습니다.", LogLevel.DEBUG),
 
     // MyPlant
     NOT_FOUND_MYPLANT(HttpStatus.NOT_FOUND, "존재하지 않는 내 식물입니다.", LogLevel.DEBUG),

--- a/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
@@ -3,10 +3,11 @@ package dnd11th.blooming.common.exception
 import org.springframework.boot.logging.LogLevel
 import org.springframework.http.HttpStatus
 
-enum class ErrorType(val status: HttpStatus, val message: String, val logLevel: LogLevel) {
+enum class ErrorType(val status: HttpStatus, var message: String, val logLevel: LogLevel) {
     // COMMON
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error has occurred.", LogLevel.ERROR),
     INVALID_DATE(HttpStatus.BAD_REQUEST, "올바르지 않은 날짜입니다.", LogLevel.DEBUG),
+    ARGUMENT_ERROR(HttpStatus.BAD_REQUEST, "올바르지 않은 요청이 포함되었습니다.", LogLevel.DEBUG),
 
     // MyPlant
     NOT_FOUND_MYPLANT(HttpStatus.NOT_FOUND, "존재하지 않는 내 식물입니다.", LogLevel.DEBUG),

--- a/src/main/kotlin/dnd11th/blooming/common/exception/FieldErrorResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/exception/FieldErrorResponse.kt
@@ -1,0 +1,6 @@
+package dnd11th.blooming.common.exception
+
+data class FieldErrorResponse(
+    val fieldName: String,
+    val message: String,
+)

--- a/src/main/kotlin/dnd11th/blooming/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/exception/GlobalExceptionHandler.kt
@@ -24,7 +24,7 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleArgumentValidationException(exception: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
-        val errorType = ErrorType.ARGUMENT_ERROR
+        val errorType = ErrorType.BAD_REQUEST
 
         // bindingResult를 순회하며 errorArgumentMap을 채운다.
         val fieldErrorList: List<FieldErrorResponse> =

--- a/src/main/kotlin/dnd11th/blooming/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/exception/GlobalExceptionHandler.kt
@@ -2,6 +2,8 @@ package dnd11th.blooming.common.exception
 
 import org.springframework.boot.logging.LogLevel
 import org.springframework.http.ResponseEntity
+import org.springframework.validation.FieldError
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
@@ -18,5 +20,30 @@ class GlobalExceptionHandler {
         return ResponseEntity
             .status(errorType.status)
             .body(ErrorResponse.from(errorType))
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleArgumentValidationException(exception: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
+        val errorType = ErrorType.ARGUMENT_ERROR
+        val errorArgumentMap = mutableMapOf<String, String>()
+
+        // bindingResult를 순회하며 errorArgumentMap을 채운다.
+        exception.bindingResult.allErrors
+            .forEach { error ->
+                run {
+                    val field = (error as? FieldError)?.field ?: return@forEach
+                    val message = error.defaultMessage ?: return@forEach
+                    errorArgumentMap[field] = message
+                }
+            }
+
+        // 가장 첫번째 bindingResult의 message를 예외의 message로 처리한다.
+        exception.bindingResult.allErrors[0].defaultMessage?.also {
+            errorType.message = it
+        }
+
+        return ResponseEntity
+            .status(exception.statusCode)
+            .body(ErrorResponse.from(ErrorType.ARGUMENT_ERROR, errorArgumentMap))
     }
 }

--- a/src/main/kotlin/dnd11th/blooming/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/exception/GlobalExceptionHandler.kt
@@ -28,7 +28,7 @@ class GlobalExceptionHandler {
 
         // bindingResult를 순회하며 errorArgumentMap을 채운다.
         val fieldErrorList: List<FieldErrorResponse> =
-            exception.bindingResult.allErrors
+            exception.bindingResult.allErrors.reversed()
                 .mapNotNull { error ->
                     val field = (error as? FieldError)?.field
                     val message = error?.defaultMessage
@@ -39,8 +39,8 @@ class GlobalExceptionHandler {
                     }
                 }
 
-        // 가장 첫번째 bindingResult의 message를 예외의 message로 처리한다.
-        exception.bindingResult.allErrors[0].defaultMessage?.also {
+        // 가장 처음 발생한 bindingResult의 message를 예외의 message로 처리한다.
+        exception.bindingResult.allErrors.last().defaultMessage?.also {
             errorType.message = it
         }
 

--- a/src/main/kotlin/dnd11th/blooming/common/exception/InvalidDateException.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/exception/InvalidDateException.kt
@@ -1,3 +1,0 @@
-package dnd11th.blooming.common.exception
-
-class InvalidDateException(errorType: ErrorType) : MyException(errorType)

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/Image.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/Image.kt
@@ -20,7 +20,7 @@ class Image(
 ) : BaseEntity(currentDate) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Long = 0
+    var id: Long? = null
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "myplant_id")

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/Location.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/Location.kt
@@ -19,7 +19,7 @@ class Location(
 ) : BaseEntity(currentDate) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Long = 0
+    var id: Long? = null
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/MyPlant.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/MyPlant.kt
@@ -31,7 +31,7 @@ class MyPlant(
 ) : BaseEntity(currentDate) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Long = 0
+    var id: Long? = null
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/kotlin/dnd11th/blooming/domain/repository/ImageRepository.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/repository/ImageRepository.kt
@@ -1,5 +1,6 @@
 package dnd11th.blooming.domain.repository
 
+import dnd11th.blooming.api.dto.myplant.MyPlantIdWithImageUrl
 import dnd11th.blooming.domain.entity.Image
 import dnd11th.blooming.domain.entity.MyPlant
 import org.springframework.data.jpa.repository.JpaRepository
@@ -10,10 +11,27 @@ import org.springframework.data.repository.query.Param
 interface ImageRepository : JpaRepository<Image, Long> {
     fun findAllByMyPlant(myPlant: MyPlant): List<Image>
 
+    @Query(
+        """
+    SELECT new dnd11th.blooming.api.dto.myplant.MyPlantIdWithImageUrl(i.url, mp.id)
+    FROM Image i
+    JOIN i.myPlant mp
+    WHERE mp IN :myPlants
+    AND i.favorite = true
+    AND i.id = (
+        SELECT MIN(i2.id)
+        FROM Image i2
+        WHERE i2.myPlant = mp
+        AND i2.favorite = true
+    )
+	""",
+    )
+    fun findFavoriteImagesForMyPlants(myPlants: List<MyPlant>): List<MyPlantIdWithImageUrl>
+
     @Modifying
     @Query(
         """
-		DELETE FROM Image i WHERE i.myPlant = :myPlant
+	DELETE FROM Image i WHERE i.myPlant = :myPlant
 	""",
     )
     fun deleteAllInBatchByMyPlant(

--- a/src/test/kotlin/dnd11th/blooming/api/controller/image/ImageControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/image/ImageControllerValidationTest.kt
@@ -2,6 +2,7 @@ package dnd11th.blooming.api.controller.image
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
+import dnd11th.blooming.api.dto.image.ImageFavoriteModifyRequest
 import dnd11th.blooming.api.dto.image.ImageSaveRequest
 import dnd11th.blooming.api.service.image.ImageService
 import dnd11th.blooming.common.exception.ErrorType
@@ -12,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
 
 @WebMvcTest(ImageController::class)
@@ -30,6 +32,24 @@ class ImageControllerValidationTest : DescribeSpec() {
 
     init {
         describe("이미지 저장") {
+            context("이미지URL을 전달하지 않으면") {
+                val request =
+                    objectMapper.writeValueAsString(
+                        ImageSaveRequest(
+                            imageUrl = null,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/myplants/1/image") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = request
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("URL은 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
             context("이미지URL을 비우고 전달하면") {
                 val request =
                     objectMapper.writeValueAsString(
@@ -44,7 +64,28 @@ class ImageControllerValidationTest : DescribeSpec() {
                     }.andExpectAll {
                         status { isBadRequest() }
                         jsonPath("$.code", equalTo(ERROR_CODE))
-                        jsonPath("$.message", equalTo("URL은 비어있을 수 없습니다."))
+                        jsonPath("$.message", equalTo("URL은 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
+        }
+
+        describe("이미지 즐겨찾기 수정") {
+            context("즐겨찾기 여부를 전달하지 않으면") {
+                val request =
+                    objectMapper.writeValueAsString(
+                        ImageFavoriteModifyRequest(
+                            favorite = null,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.patch("/api/v1/myplants/image/1") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = request
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("즐겨찾기 여부는 필수값입니다."))
                     }.andDo { print() }
                 }
             }

--- a/src/test/kotlin/dnd11th/blooming/api/controller/image/ImageControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/image/ImageControllerValidationTest.kt
@@ -34,7 +34,7 @@ class ImageControllerValidationTest : DescribeSpec() {
                 val request =
                     objectMapper.writeValueAsString(
                         ImageSaveRequest(
-                            imageUrl = "",
+                            imageUrl = " ",
                         ),
                     )
                 it("예외 응답이 와야 한다.") {

--- a/src/test/kotlin/dnd11th/blooming/api/controller/image/ImageControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/image/ImageControllerValidationTest.kt
@@ -93,6 +93,6 @@ class ImageControllerValidationTest : DescribeSpec() {
     }
 
     companion object {
-        val ERROR_CODE = ErrorType.ARGUMENT_ERROR.name
+        val ERROR_CODE = ErrorType.BAD_REQUEST.name
     }
 }

--- a/src/test/kotlin/dnd11th/blooming/api/controller/image/ImageControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/image/ImageControllerValidationTest.kt
@@ -1,0 +1,57 @@
+package dnd11th.blooming.api.controller.image
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import dnd11th.blooming.api.dto.image.ImageSaveRequest
+import dnd11th.blooming.api.service.image.ImageService
+import dnd11th.blooming.common.exception.ErrorType
+import dnd11th.blooming.common.jwt.JwtProvider
+import io.kotest.core.spec.style.DescribeSpec
+import org.hamcrest.CoreMatchers.equalTo
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+
+@WebMvcTest(ImageController::class)
+class ImageControllerValidationTest : DescribeSpec() {
+    @MockkBean
+    private lateinit var imageService: ImageService
+
+    @MockkBean
+    private lateinit var jwtProvider: JwtProvider
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    init {
+        describe("이미지 저장") {
+            context("이미지URL을 비우고 전달하면") {
+                val request =
+                    objectMapper.writeValueAsString(
+                        ImageSaveRequest(
+                            imageUrl = "",
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/myplants/1/image") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = request
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("URL은 비어있을 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+        }
+    }
+
+    companion object {
+        val ERROR_CODE = ErrorType.ARGUMENT_ERROR.name
+    }
+}

--- a/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerTest.kt
@@ -106,7 +106,7 @@ class LocationControllerTest : DescribeSpec() {
                 val request =
                     objectMapper.writeValueAsString(
                         LocationModifyRequest(
-                            _name = LOCATION_NAME2,
+                            name = LOCATION_NAME2,
                         ),
                     )
                 it("수정된 위치가 반환되어야 한다.") {
@@ -124,7 +124,7 @@ class LocationControllerTest : DescribeSpec() {
                 val request =
                     objectMapper.writeValueAsString(
                         LocationModifyRequest(
-                            _name = LOCATION_NAME2,
+                            name = LOCATION_NAME2,
                         ),
                     )
                 it("예외 응답이 반환되어야 한다.") {

--- a/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerTest.kt
@@ -106,7 +106,7 @@ class LocationControllerTest : DescribeSpec() {
                 val request =
                     objectMapper.writeValueAsString(
                         LocationModifyRequest(
-                            name = LOCATION_NAME2,
+                            _name = LOCATION_NAME2,
                         ),
                     )
                 it("수정된 위치가 반환되어야 한다.") {
@@ -124,7 +124,7 @@ class LocationControllerTest : DescribeSpec() {
                 val request =
                     objectMapper.writeValueAsString(
                         LocationModifyRequest(
-                            name = LOCATION_NAME2,
+                            _name = LOCATION_NAME2,
                         ),
                     )
                 it("예외 응답이 반환되어야 한다.") {

--- a/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerValidationTest.kt
@@ -1,0 +1,82 @@
+package dnd11th.blooming.api.controller.location
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import dnd11th.blooming.api.dto.location.LocationModifyRequest
+import dnd11th.blooming.api.dto.location.LocationSaveRequest
+import dnd11th.blooming.api.service.location.LocationService
+import dnd11th.blooming.common.exception.ErrorType
+import dnd11th.blooming.common.jwt.JwtProvider
+import io.kotest.core.spec.style.DescribeSpec
+import org.hamcrest.CoreMatchers.equalTo
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.patch
+import org.springframework.test.web.servlet.post
+
+@WebMvcTest(LocationController::class)
+class LocationControllerValidationTest : DescribeSpec() {
+    @MockkBean
+    private lateinit var locationService: LocationService
+
+    @MockkBean
+    private lateinit var jwtProvider: JwtProvider
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    init {
+        describe("위치 저장") {
+            context("위치명을 비우고 전달하면") {
+                val request =
+                    objectMapper.writeValueAsString(
+                        LocationSaveRequest(
+                            name = "",
+                        ),
+                    )
+                it("예외 응답이 반환되어야 한다.") {
+                    mockMvc.post("/api/v1/location") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = request
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("새로운 위치명은 비어있을 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+        }
+
+        describe("위치 이름 수정") {
+            context("위치명을 비우고 전달하면") {
+                val request =
+                    objectMapper.writeValueAsString(
+                        LocationModifyRequest(
+                            name = "",
+                        ),
+                    )
+                it("수정된 위치가 반환되어야 한다.") {
+                    mockMvc.patch("/api/v1/location/$LOCATION_ID") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = request
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("새로운 위치명은 비어있을 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+        }
+    }
+
+    companion object {
+        val ERROR_CODE = ErrorType.ARGUMENT_ERROR.name
+
+        const val LOCATION_ID = 1L
+    }
+}

--- a/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerValidationTest.kt
@@ -32,6 +32,24 @@ class LocationControllerValidationTest : DescribeSpec() {
 
     init {
         describe("위치 저장") {
+            context("위치명을 전달하지 않으면") {
+                val request =
+                    objectMapper.writeValueAsString(
+                        LocationSaveRequest(
+                            name = null,
+                        ),
+                    )
+                it("예외 응답이 반환되어야 한다.") {
+                    mockMvc.post("/api/v1/location") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = request
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("새로운 위치명은 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
             context("위치명을 비우고 전달하면") {
                 val request =
                     objectMapper.writeValueAsString(
@@ -46,18 +64,18 @@ class LocationControllerValidationTest : DescribeSpec() {
                     }.andExpectAll {
                         status { isBadRequest() }
                         jsonPath("$.code", equalTo(ERROR_CODE))
-                        jsonPath("$.message", equalTo("새로운 위치명은 비어있을 수 없습니다."))
+                        jsonPath("$.message", equalTo("새로운 위치명은 필수값입니다."))
                     }.andDo { print() }
                 }
             }
         }
 
         describe("위치 이름 수정") {
-            context("위치명을 비우고 전달하면") {
+            context("위치명을 전달하지 않으면") {
                 val request =
                     objectMapper.writeValueAsString(
                         LocationModifyRequest(
-                            _name = "",
+                            name = null,
                         ),
                     )
                 it("수정된 위치가 반환되어야 한다.") {
@@ -67,7 +85,25 @@ class LocationControllerValidationTest : DescribeSpec() {
                     }.andExpectAll {
                         status { isBadRequest() }
                         jsonPath("$.code", equalTo(ERROR_CODE))
-                        jsonPath("$.message", equalTo("새로운 위치명은 비어있을 수 없습니다."))
+                        jsonPath("$.message", equalTo("새로운 위치명은 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("위치명을 비우고 전달하면") {
+                val request =
+                    objectMapper.writeValueAsString(
+                        LocationModifyRequest(
+                            name = "",
+                        ),
+                    )
+                it("수정된 위치가 반환되어야 한다.") {
+                    mockMvc.patch("/api/v1/location/$LOCATION_ID") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = request
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("새로운 위치명은 필수값입니다."))
                     }.andDo { print() }
                 }
             }

--- a/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerValidationTest.kt
@@ -57,7 +57,7 @@ class LocationControllerValidationTest : DescribeSpec() {
                 val request =
                     objectMapper.writeValueAsString(
                         LocationModifyRequest(
-                            name = "",
+                            _name = "",
                         ),
                     )
                 it("수정된 위치가 반환되어야 한다.") {

--- a/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerValidationTest.kt
@@ -111,7 +111,7 @@ class LocationControllerValidationTest : DescribeSpec() {
     }
 
     companion object {
-        val ERROR_CODE = ErrorType.ARGUMENT_ERROR.name
+        val ERROR_CODE = ErrorType.BAD_REQUEST.name
 
         const val LOCATION_ID = 1L
     }

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
@@ -363,7 +363,7 @@ class MyPlantControllerTest : DescribeSpec() {
                 val request =
                     objectMapper.writeValueAsString(
                         MyPlantHealthCheckRequest(
-                            _healthCheck = true,
+                            healthCheck = true,
                         ),
                     )
                 it("정상 흐름이 반환된다.") {

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
@@ -363,7 +363,7 @@ class MyPlantControllerTest : DescribeSpec() {
                 val request =
                     objectMapper.writeValueAsString(
                         MyPlantHealthCheckRequest(
-                            healthCheck = true,
+                            _healthCheck = true,
                         ),
                     )
                 it("정상 흐름이 반환된다.") {

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
@@ -87,6 +87,7 @@ class MyPlantControllerTest : DescribeSpec() {
                     MyPlantResponse(
                         myPlantId = MYPLANT_ID,
                         nickname = NICKNAME,
+                        imageUrl = IMAGE_URL,
                         scientificName = SCIENTIFIC_NAME,
                         waterRemainDay = WATER_REAMIN_DAY,
                         fertilizerRemainDay = FERTILIZER_REAMIN_DAY,
@@ -94,6 +95,7 @@ class MyPlantControllerTest : DescribeSpec() {
                     MyPlantResponse(
                         myPlantId = MYPLANT_ID2,
                         nickname = NICKNAME2,
+                        imageUrl = IMAGE_URL,
                         scientificName = SCIENTIFIC_NAME2,
                         waterRemainDay = WATER_REAMIN_DAY,
                         fertilizerRemainDay = FERTILIZER_REAMIN_DAY,
@@ -123,6 +125,7 @@ class MyPlantControllerTest : DescribeSpec() {
                     MyPlantResponse(
                         myPlantId = MYPLANT_ID,
                         nickname = NICKNAME,
+                        imageUrl = IMAGE_URL,
                         scientificName = SCIENTIFIC_NAME,
                         waterRemainDay = WATER_REAMIN_DAY,
                         fertilizerRemainDay = FERTILIZER_REAMIN_DAY,
@@ -431,6 +434,7 @@ class MyPlantControllerTest : DescribeSpec() {
         val CURRENT_DAY: LocalDate = LocalDate.now()
 
         const val PLANT_ID = 1L
+        const val IMAGE_URL = "http://"
 
         const val MYPLANT_ID = 1L
         const val SCIENTIFIC_NAME = "몬스테라 델리오사"

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
@@ -46,7 +46,7 @@ class MyPlantControllerTest : DescribeSpec() {
     init {
         describe("내 식물 저장") {
             beforeTest {
-                every { myPlantService.saveMyPlant(any()) } returns
+                every { myPlantService.saveMyPlant(any(), any()) } returns
                     MyPlantSaveResponse(
                         myPlantId = MYPLANT_ID,
                     )

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
@@ -48,14 +48,14 @@ class MyPlantControllerTest : DescribeSpec() {
             beforeTest {
                 every { myPlantService.saveMyPlant(any()) } returns
                     MyPlantSaveResponse(
-                        myPlantId = ID,
+                        myPlantId = MYPLANT_ID,
                     )
             }
             context("정상적인 요청으로 저장하면") {
                 val json =
                     objectMapper.writeValueAsString(
                         MyPlantSaveRequest(
-                            scientificName = SCIENTIFIC_NAME,
+                            plantId = PLANT_ID,
                             nickname = NICKNAME,
                             locationId = LOCATION_ID,
                             startDate = START_DATE,
@@ -74,7 +74,7 @@ class MyPlantControllerTest : DescribeSpec() {
                         content = json
                     }.andExpectAll {
                         status { isOk() }
-                        jsonPath("$.myPlantId", equalTo(ID.toInt()))
+                        jsonPath("$.myPlantId", equalTo(MYPLANT_ID.toInt()))
                         jsonPath("$.message", equalTo("등록 되었습니다."))
                     }.andDo { print() }
                 }
@@ -85,14 +85,14 @@ class MyPlantControllerTest : DescribeSpec() {
             every { myPlantService.findAllMyPlant(any(), any(), any()) } returns
                 listOf(
                     MyPlantResponse(
-                        myPlantId = ID,
+                        myPlantId = MYPLANT_ID,
                         nickname = NICKNAME,
                         scientificName = SCIENTIFIC_NAME,
                         waterRemainDay = WATER_REAMIN_DAY,
                         fertilizerRemainDay = FERTILIZER_REAMIN_DAY,
                     ),
                     MyPlantResponse(
-                        myPlantId = ID2,
+                        myPlantId = MYPLANT_ID2,
                         nickname = NICKNAME2,
                         scientificName = SCIENTIFIC_NAME2,
                         waterRemainDay = WATER_REAMIN_DAY,
@@ -105,12 +105,12 @@ class MyPlantControllerTest : DescribeSpec() {
                         .andExpectAll {
                             status { isOk() }
                             jsonPath("$.size()", equalTo(2))
-                            jsonPath("$[0].myPlantId", equalTo(ID.toInt()))
+                            jsonPath("$[0].myPlantId", equalTo(MYPLANT_ID.toInt()))
                             jsonPath("$[0].nickname", equalTo(NICKNAME))
                             jsonPath("$[0].scientificName", equalTo(SCIENTIFIC_NAME))
                             jsonPath("$[0].waterRemainDay", equalTo(WATER_REAMIN_DAY))
                             jsonPath("$[0].fertilizerRemainDay", equalTo(FERTILIZER_REAMIN_DAY))
-                            jsonPath("$[1].myPlantId", equalTo(ID2.toInt()))
+                            jsonPath("$[1].myPlantId", equalTo(MYPLANT_ID2.toInt()))
                             jsonPath("$[1].nickname", equalTo(NICKNAME2))
                             jsonPath("$[1].scientificName", equalTo(SCIENTIFIC_NAME2))
                             jsonPath("$[1].waterRemainDay", equalTo(WATER_REAMIN_DAY))
@@ -121,7 +121,7 @@ class MyPlantControllerTest : DescribeSpec() {
             every { myPlantService.findAllMyPlant(any(), LOCATION_ID, any()) } returns
                 listOf(
                     MyPlantResponse(
-                        myPlantId = ID,
+                        myPlantId = MYPLANT_ID,
                         nickname = NICKNAME,
                         scientificName = SCIENTIFIC_NAME,
                         waterRemainDay = WATER_REAMIN_DAY,
@@ -136,7 +136,7 @@ class MyPlantControllerTest : DescribeSpec() {
                         .andExpectAll {
                             status { isOk() }
                             jsonPath("$.size()", equalTo(1))
-                            jsonPath("$[0].myPlantId", equalTo(ID.toInt()))
+                            jsonPath("$[0].myPlantId", equalTo(MYPLANT_ID.toInt()))
                             jsonPath("$[0].nickname", equalTo(NICKNAME))
                             jsonPath("$[0].scientificName", equalTo(SCIENTIFIC_NAME))
                             jsonPath("$[0].waterRemainDay", equalTo(WATER_REAMIN_DAY))
@@ -148,7 +148,7 @@ class MyPlantControllerTest : DescribeSpec() {
 
         describe("내 식물 상세 조회") {
             beforeTest {
-                every { myPlantService.findMyPlantDetail(ID, any()) } returns
+                every { myPlantService.findMyPlantDetail(MYPLANT_ID, any()) } returns
                     MyPlantDetailResponse(
                         nickname = NICKNAME,
                         scientificName = SCIENTIFIC_NAME,
@@ -177,12 +177,12 @@ class MyPlantControllerTest : DescribeSpec() {
                                 ),
                             ),
                     )
-                every { myPlantService.findMyPlantDetail(ID2, any()) } throws
+                every { myPlantService.findMyPlantDetail(MYPLANT_ID2, any()) } throws
                     NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
             }
             context("존재하는 ID로 조회하면") {
                 it("내 식물이 조회되어야 한다.") {
-                    mockMvc.get("/api/v1/plants/$ID")
+                    mockMvc.get("/api/v1/plants/$MYPLANT_ID")
                         .andExpectAll {
                             status { isOk() }
                             jsonPath("$.nickname", equalTo(NICKNAME))
@@ -206,7 +206,7 @@ class MyPlantControllerTest : DescribeSpec() {
             }
             context("존재하지 않는 ID로 조회하면") {
                 it("예외응답이 반한되어야 한다.") {
-                    mockMvc.get("/api/v1/plants/$ID2")
+                    mockMvc.get("/api/v1/plants/$MYPLANT_ID2")
                         .andExpectAll {
                             status { isNotFound() }
                             jsonPath("$.message", equalTo("존재하지 않는 내 식물입니다."))
@@ -219,7 +219,7 @@ class MyPlantControllerTest : DescribeSpec() {
         describe("내 식물 수정") {
             beforeTest {
                 every { myPlantService.modifyMyPlant(any(), any()) } just runs
-                every { myPlantService.modifyMyPlant(not(eq(ID)), any()) } throws
+                every { myPlantService.modifyMyPlant(not(eq(MYPLANT_ID)), any()) } throws
                     NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
                 every {
                     myPlantService.modifyMyPlant(
@@ -243,7 +243,7 @@ class MyPlantControllerTest : DescribeSpec() {
                         ),
                     )
                 it("정상 흐름이 반환되어야 한다.") {
-                    mockMvc.patch("/api/v1/plants/$ID") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID") {
                         contentType = MediaType.APPLICATION_JSON
                         content = request
                     }.andExpectAll {
@@ -263,7 +263,7 @@ class MyPlantControllerTest : DescribeSpec() {
                         ),
                     )
                 it("예외응답이 반환되어야 한다.") {
-                    mockMvc.patch("/api/v1/plants/$ID2") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID2") {
                         contentType = MediaType.APPLICATION_JSON
                         content = request
                     }.andExpectAll {
@@ -285,7 +285,7 @@ class MyPlantControllerTest : DescribeSpec() {
                         ),
                     )
                 it("예외응답이 반환되어야 한다.") {
-                    mockMvc.patch("/api/v1/plants/$ID2") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID2") {
                         contentType = MediaType.APPLICATION_JSON
                         content = request
                     }.andExpectAll {
@@ -300,12 +300,12 @@ class MyPlantControllerTest : DescribeSpec() {
         describe("내 식물 삭제") {
             beforeTest {
                 every { myPlantService.deleteMyPlant(any()) } just runs
-                every { myPlantService.deleteMyPlant(not(eq(ID))) } throws
+                every { myPlantService.deleteMyPlant(not(eq(MYPLANT_ID))) } throws
                     NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
             }
             context("정상 요청으로 삭제하면") {
                 it("정상 흐름이 반환되어야 한다.") {
-                    mockMvc.delete("/api/v1/plants/$ID")
+                    mockMvc.delete("/api/v1/plants/$MYPLANT_ID")
                         .andExpectAll {
                             status { isOk() }
                         }.andDo { print() }
@@ -313,7 +313,7 @@ class MyPlantControllerTest : DescribeSpec() {
             }
             context("존재하지 않는 내 식물 ID로 삭제하면") {
                 it("예외응답이 반환되어야 한다.") {
-                    mockMvc.delete("/api/v1/plants/$ID2")
+                    mockMvc.delete("/api/v1/plants/$MYPLANT_ID2")
                         .andExpectAll {
                             status { isNotFound() }
                             jsonPath("$.message", equalTo("존재하지 않는 내 식물입니다."))
@@ -330,7 +330,7 @@ class MyPlantControllerTest : DescribeSpec() {
             }
             context("물주기 요청을 하면") {
                 it("정상 흐름이 반환된다.") {
-                    mockMvc.post("/api/v1/plants/$ID/water")
+                    mockMvc.post("/api/v1/plants/$MYPLANT_ID/water")
                         .andExpectAll {
                             status { isOk() }
                         }.andDo { print() }
@@ -344,7 +344,7 @@ class MyPlantControllerTest : DescribeSpec() {
             }
             context("물주기 요청을 하면") {
                 it("정상 흐름이 반환된다.") {
-                    mockMvc.post("/api/v1/plants/$ID/fertilizer")
+                    mockMvc.post("/api/v1/plants/$MYPLANT_ID/fertilizer")
                         .andExpectAll {
                             status { isOk() }
                         }.andDo { print() }
@@ -364,7 +364,7 @@ class MyPlantControllerTest : DescribeSpec() {
                         ),
                     )
                 it("정상 흐름이 반환된다.") {
-                    mockMvc.patch("/api/v1/plants/$ID/healthcheck") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID/healthcheck") {
                         contentType = MediaType.APPLICATION_JSON
                         content = request
                     }.andExpectAll {
@@ -376,8 +376,8 @@ class MyPlantControllerTest : DescribeSpec() {
 
         describe("내 식물의 알림 수정") {
             beforeTest {
-                every { myPlantService.modifyMyPlantAlarm(ID, any()) } just runs
-                every { myPlantService.modifyMyPlantAlarm(not(eq(ID)), any()) } throws
+                every { myPlantService.modifyMyPlantAlarm(MYPLANT_ID, any()) } just runs
+                every { myPlantService.modifyMyPlantAlarm(not(eq(MYPLANT_ID)), any()) } throws
                     NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
             }
             context("존재하는 ID로 수정하면") {
@@ -392,7 +392,7 @@ class MyPlantControllerTest : DescribeSpec() {
                         ),
                     )
                 it("정상응답이 반환되어야 한다.") {
-                    mockMvc.patch("/api/v1/plants/$ID/alarm") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID/alarm") {
                         contentType = MediaType.APPLICATION_JSON
                         content = json
                     }
@@ -413,7 +413,7 @@ class MyPlantControllerTest : DescribeSpec() {
                         ),
                     )
                 it("예외응답이 반환되어야 한다.") {
-                    mockMvc.patch("/api/v1/plants/$ID2/alarm") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID2/alarm") {
                         contentType = MediaType.APPLICATION_JSON
                         content = json
                     }
@@ -430,7 +430,9 @@ class MyPlantControllerTest : DescribeSpec() {
     companion object {
         val CURRENT_DAY: LocalDate = LocalDate.now()
 
-        const val ID = 1L
+        const val PLANT_ID = 1L
+
+        const val MYPLANT_ID = 1L
         const val SCIENTIFIC_NAME = "몬스테라 델리오사"
         const val NICKNAME = "뿡뿡이"
         const val LOCATION_ID = 100L
@@ -441,7 +443,7 @@ class MyPlantControllerTest : DescribeSpec() {
         const val WATER_REAMIN_DAY = 3
         const val FERTILIZER_REAMIN_DAY = 3
 
-        const val ID2 = 2L
+        const val MYPLANT_ID2 = 2L
         const val SCIENTIFIC_NAME2 = "병아리 눈물"
         const val NICKNAME2 = "빵빵이"
 

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
@@ -33,39 +33,11 @@ class MyPlantControllerValidationTest : DescribeSpec() {
 
     init {
         describe("내 식물 저장") {
-            context("식물 종류를 비우고 전달하면") {
-                val json =
-                    objectMapper.writeValueAsString(
-                        MyPlantSaveRequest(
-                            scientificName = " ",
-                            nickname = NICKNAME,
-                            locationId = LOCATION_ID,
-                            startDate = START_DATE,
-                            lastWateredDate = LAST_WATERED_DATE,
-                            lastFertilizerDate = LAST_FERTILIZER_DATE,
-                            waterAlarm = WATER_ALARM,
-                            waterPeriod = WATER_PERIOD,
-                            fertilizerAlarm = FERTILIZER_ALARM,
-                            fertilizerPeriod = FERTILIZER_PERIOD,
-                            healthCheckAlarm = HEALTHCHECK_ALARM,
-                        ),
-                    )
-                it("예외 응답이 와야 한다.") {
-                    mockMvc.post("/api/v1/plants") {
-                        contentType = MediaType.APPLICATION_JSON
-                        content = json
-                    }.andExpectAll {
-                        status { isBadRequest() }
-                        jsonPath("$.code", equalTo(ERROR_CODE))
-                        jsonPath("$.message", equalTo("식물 종류는 비어있을 수 없습니다."))
-                    }.andDo { print() }
-                }
-            }
             context("식물 별명을 비우고 전달하면") {
                 val json =
                     objectMapper.writeValueAsString(
                         MyPlantSaveRequest(
-                            scientificName = SCIENTIFIC_NAME,
+                            plantId = PLANT_ID,
                             nickname = " ",
                             locationId = LOCATION_ID,
                             startDate = START_DATE,
@@ -93,7 +65,7 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                 val json =
                     objectMapper.writeValueAsString(
                         MyPlantSaveRequest(
-                            scientificName = SCIENTIFIC_NAME,
+                            plantId = PLANT_ID,
                             nickname = NICKNAME,
                             locationId = LOCATION_ID,
                             startDate = FUTURE_DATE,
@@ -121,7 +93,7 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                 val json =
                     objectMapper.writeValueAsString(
                         MyPlantSaveRequest(
-                            scientificName = SCIENTIFIC_NAME,
+                            plantId = PLANT_ID,
                             nickname = NICKNAME,
                             locationId = LOCATION_ID,
                             startDate = START_DATE,
@@ -149,7 +121,7 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                 val json =
                     objectMapper.writeValueAsString(
                         MyPlantSaveRequest(
-                            scientificName = SCIENTIFIC_NAME,
+                            plantId = PLANT_ID,
                             nickname = NICKNAME,
                             locationId = LOCATION_ID,
                             startDate = START_DATE,
@@ -188,7 +160,7 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                         ),
                     )
                 it("예외 응답이 와야 한다.") {
-                    mockMvc.patch("/api/v1/plants/$PLANT_ID") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID") {
                         contentType = MediaType.APPLICATION_JSON
                         content = json
                     }.andExpectAll {
@@ -210,7 +182,7 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                         ),
                     )
                 it("예외 응답이 와야 한다.") {
-                    mockMvc.patch("/api/v1/plants/$PLANT_ID") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID") {
                         contentType = MediaType.APPLICATION_JSON
                         content = json
                     }.andExpectAll {
@@ -232,7 +204,7 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                         ),
                     )
                 it("예외 응답이 와야 한다.") {
-                    mockMvc.patch("/api/v1/plants/$PLANT_ID") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID") {
                         contentType = MediaType.APPLICATION_JSON
                         content = json
                     }.andExpectAll {
@@ -254,7 +226,7 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                         ),
                     )
                 it("예외 응답이 와야 한다.") {
-                    mockMvc.patch("/api/v1/plants/$PLANT_ID") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID") {
                         contentType = MediaType.APPLICATION_JSON
                         content = json
                     }.andExpectAll {
@@ -270,6 +242,7 @@ class MyPlantControllerValidationTest : DescribeSpec() {
     companion object {
         val ERROR_CODE = ErrorType.ARGUMENT_ERROR.name
         const val PLANT_ID = 1L
+        const val MYPLANT_ID = 1L
         const val SCIENTIFIC_NAME = "몬스테라 델리오사"
         const val NICKNAME = "뿡뿡이"
         const val LOCATION_ID = 100L

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
@@ -1,0 +1,78 @@
+package dnd11th.blooming.api.controller.myplant
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import dnd11th.blooming.api.dto.myplant.MyPlantSaveRequest
+import dnd11th.blooming.api.service.myplant.MyPlantService
+import dnd11th.blooming.common.exception.ErrorType
+import dnd11th.blooming.common.jwt.JwtProvider
+import io.kotest.core.spec.style.DescribeSpec
+import org.hamcrest.CoreMatchers.equalTo
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import java.time.LocalDate
+
+@WebMvcTest(MyPlantController::class)
+class MyPlantControllerValidationTest : DescribeSpec() {
+    @MockkBean
+    private lateinit var myPlantService: MyPlantService
+
+    @MockkBean
+    private lateinit var jwtProvider: JwtProvider
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    init {
+        describe("내 식물 저장") {
+            context("식물 종류를 비우고 전달하면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantSaveRequest(
+                            scientificName = "",
+                            nickname = NICKNAME,
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/plants") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("식물 종류는 비어있을 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+        }
+    }
+
+    companion object {
+        val ERROR_CODE = ErrorType.ARGUMENT_ERROR.name
+        const val NICKNAME = "뿡뿡이"
+        const val LOCATION_ID = 100L
+        val START_DATE: LocalDate = LocalDate.of(2024, 4, 19)
+        val LAST_WATERED_DATE: LocalDate = LocalDate.of(2024, 6, 29)
+        val LAST_FERTILIZER_DATE: LocalDate = LocalDate.of(2024, 6, 15)
+        const val WATER_ALARM = true
+        const val WATER_PERIOD = 3
+        const val FERTILIZER_ALARM = false
+        const val FERTILIZER_PERIOD = 30
+        const val HEALTHCHECK_ALARM = true
+    }
+}

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
@@ -2,6 +2,7 @@ package dnd11th.blooming.api.controller.myplant
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
+import dnd11th.blooming.api.dto.myplant.MyPlantModifyRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantSaveRequest
 import dnd11th.blooming.api.service.myplant.MyPlantService
 import dnd11th.blooming.common.exception.ErrorType
@@ -12,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
 import java.time.LocalDate
 
@@ -35,7 +37,7 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                 val json =
                     objectMapper.writeValueAsString(
                         MyPlantSaveRequest(
-                            scientificName = "",
+                            scientificName = " ",
                             nickname = NICKNAME,
                             locationId = LOCATION_ID,
                             startDate = START_DATE,
@@ -59,13 +61,219 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                     }.andDo { print() }
                 }
             }
+            context("식물 별명을 비우고 전달하면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantSaveRequest(
+                            scientificName = SCIENTIFIC_NAME,
+                            nickname = " ",
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/plants") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("식물 별명은 비어있을 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("키우기 시작한 날짜를 미래로 전달하면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantSaveRequest(
+                            scientificName = SCIENTIFIC_NAME,
+                            nickname = NICKNAME,
+                            locationId = LOCATION_ID,
+                            startDate = FUTURE_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/plants") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("키우기 시작한 날짜는 미래일 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("마지막으로 물 준 날짜를 미래로 전달하면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantSaveRequest(
+                            scientificName = SCIENTIFIC_NAME,
+                            nickname = NICKNAME,
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = FUTURE_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/plants") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("마지막으로 물 준 날짜는 미래일 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("마지막으로 비료 준 날짜를 미래로 전달하면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantSaveRequest(
+                            scientificName = SCIENTIFIC_NAME,
+                            nickname = NICKNAME,
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = FUTURE_DATE,
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/plants") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("마지막으로 비료 준 날짜는 미래일 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+        }
+
+        describe("내 식물 수정") {
+            context("식물 별명을 비우고 전달하면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantModifyRequest(
+                            nickname = " ",
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.patch("/api/v1/plants/$PLANT_ID") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("식물 별명은 비어있을 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("키우기 시작한 날짜를 미래로 전달하면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantModifyRequest(
+                            nickname = NICKNAME,
+                            locationId = LOCATION_ID,
+                            startDate = FUTURE_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.patch("/api/v1/plants/$PLANT_ID") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("키우기 시작한 날짜는 미래일 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("마지막으로 물 준 날짜를 미래로 전달하면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantModifyRequest(
+                            nickname = NICKNAME,
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = FUTURE_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.patch("/api/v1/plants/$PLANT_ID") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("마지막으로 물 준 날짜는 미래일 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("마지막으로 비료 준 날짜를 미래로 전달하면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantModifyRequest(
+                            nickname = NICKNAME,
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = FUTURE_DATE,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.patch("/api/v1/plants/$PLANT_ID") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("마지막으로 비료 준 날짜는 미래일 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
         }
     }
 
     companion object {
         val ERROR_CODE = ErrorType.ARGUMENT_ERROR.name
+        const val PLANT_ID = 1L
+        const val SCIENTIFIC_NAME = "몬스테라 델리오사"
         const val NICKNAME = "뿡뿡이"
         const val LOCATION_ID = 100L
+        val FUTURE_DATE: LocalDate = LocalDate.now().plusDays(1)
         val START_DATE: LocalDate = LocalDate.of(2024, 4, 19)
         val LAST_WATERED_DATE: LocalDate = LocalDate.of(2024, 6, 29)
         val LAST_FERTILIZER_DATE: LocalDate = LocalDate.of(2024, 6, 15)

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
@@ -148,28 +148,6 @@ class MyPlantControllerValidationTest : DescribeSpec() {
         }
 
         describe("내 식물 수정") {
-            context("식물 별명을 비우고 전달하면") {
-                val json =
-                    objectMapper.writeValueAsString(
-                        MyPlantModifyRequest(
-                            nickname = " ",
-                            locationId = LOCATION_ID,
-                            startDate = START_DATE,
-                            lastWateredDate = LAST_WATERED_DATE,
-                            lastFertilizerDate = LAST_FERTILIZER_DATE,
-                        ),
-                    )
-                it("예외 응답이 와야 한다.") {
-                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID") {
-                        contentType = MediaType.APPLICATION_JSON
-                        content = json
-                    }.andExpectAll {
-                        status { isBadRequest() }
-                        jsonPath("$.code", equalTo(ERROR_CODE))
-                        jsonPath("$.message", equalTo("식물 별명은 비어있을 수 없습니다."))
-                    }.andDo { print() }
-                }
-            }
             context("키우기 시작한 날짜를 미래로 전달하면") {
                 val json =
                     objectMapper.writeValueAsString(

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
@@ -478,7 +478,7 @@ class MyPlantControllerValidationTest : DescribeSpec() {
     }
 
     companion object {
-        val ERROR_CODE = ErrorType.ARGUMENT_ERROR.name
+        val ERROR_CODE = ErrorType.BAD_REQUEST.name
         const val PLANT_ID = 1L
         const val MYPLANT_ID = 1L
         const val SCIENTIFIC_NAME = "몬스테라 델리오사"

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
@@ -2,6 +2,8 @@ package dnd11th.blooming.api.controller.myplant
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
+import dnd11th.blooming.api.dto.myplant.AlarmModifyRequest
+import dnd11th.blooming.api.dto.myplant.MyPlantHealthCheckRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantModifyRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantSaveRequest
 import dnd11th.blooming.api.service.myplant.MyPlantService
@@ -33,6 +35,62 @@ class MyPlantControllerValidationTest : DescribeSpec() {
 
     init {
         describe("내 식물 저장") {
+            context("식물종류를 전달하지 않으면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantSaveRequest(
+                            plantId = null,
+                            nickname = NICKNAME,
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/plants") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("식물 종류는 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("식물 별명을 전달하지 않으면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantSaveRequest(
+                            plantId = PLANT_ID,
+                            nickname = null,
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/plants") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("식물 별명은 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
             context("식물 별명을 비우고 전달하면") {
                 val json =
                     objectMapper.writeValueAsString(
@@ -57,7 +115,35 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                     }.andExpectAll {
                         status { isBadRequest() }
                         jsonPath("$.code", equalTo(ERROR_CODE))
-                        jsonPath("$.message", equalTo("식물 별명은 비어있을 수 없습니다."))
+                        jsonPath("$.message", equalTo("식물 별명은 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("식물위치를 전달하지 않으면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantSaveRequest(
+                            plantId = PLANT_ID,
+                            nickname = NICKNAME,
+                            locationId = null,
+                            startDate = START_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/plants") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("위치는 필수값입니다."))
                     }.andDo { print() }
                 }
             }
@@ -142,6 +228,90 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                         status { isBadRequest() }
                         jsonPath("$.code", equalTo(ERROR_CODE))
                         jsonPath("$.message", equalTo("마지막으로 비료 준 날짜는 미래일 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("물주기 알림 여부를 전달하지 않으면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantSaveRequest(
+                            plantId = PLANT_ID,
+                            nickname = NICKNAME,
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                            waterAlarm = null,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/plants") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("물주기 알림 여부는 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("비료주기 알림 여부를 전달하지 않으면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantSaveRequest(
+                            plantId = PLANT_ID,
+                            nickname = NICKNAME,
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = null,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/plants") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("비료주기 알림 여부는 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("건강확인 알림 여부를 전달하지 않으면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantSaveRequest(
+                            plantId = PLANT_ID,
+                            nickname = NICKNAME,
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = null,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/plants") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("건강확인 알림 여부는 필수값입니다."))
                     }.andDo { print() }
                 }
             }
@@ -211,6 +381,96 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                         status { isBadRequest() }
                         jsonPath("$.code", equalTo(ERROR_CODE))
                         jsonPath("$.message", equalTo("마지막으로 비료 준 날짜는 미래일 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+        }
+
+        describe("내 식물 알림 수정") {
+            context("물주기 알림 여부를 전달하지 않으면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        AlarmModifyRequest(
+                            waterAlarm = null,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID/alarm") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("물주기 알림 여부는 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("비료주기 알림 여부를 전달하지 않으면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        AlarmModifyRequest(
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = null,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID/alarm") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("비료주기 알림 여부는 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("건강확인 알림 여부를 전달하지 않으면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        AlarmModifyRequest(
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = null,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID/alarm") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("건강확인 알림 여부는 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
+        }
+
+        describe("내 식물 건강확인") {
+            context("건강확인 알림 여부를 전달하지 않으면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantHealthCheckRequest(
+                            healthCheck = null,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID/healthcheck") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("건강확인 알림 여부는 필수값입니다."))
                     }.andDo { print() }
                 }
             }

--- a/src/test/kotlin/dnd11th/blooming/api/service/location/LocationServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/location/LocationServiceTest.kt
@@ -82,7 +82,7 @@ class LocationServiceTest : DescribeSpec(
             context("존재하는 ID의 위치를 수정하면") {
                 val request =
                     LocationModifyRequest(
-                        name = MODIFIED_LOCATION_NAME,
+                        _name = MODIFIED_LOCATION_NAME,
                     )
                 it("위치가 수정되고, 수정된 위치가 조회되어야 한다.") {
                     val response = locationService.modifyLocation(LOCATION_ID, request)
@@ -93,7 +93,7 @@ class LocationServiceTest : DescribeSpec(
             context("존재하지 않는 ID의 위치를 수정하면") {
                 val request =
                     LocationModifyRequest(
-                        name = MODIFIED_LOCATION_NAME,
+                        _name = MODIFIED_LOCATION_NAME,
                     )
                 it("NotFoundException(NOT_FOUND_LOCATION_ID) 예외가 발생해야 한다.") {
                     val exception =

--- a/src/test/kotlin/dnd11th/blooming/api/service/location/LocationServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/location/LocationServiceTest.kt
@@ -82,7 +82,7 @@ class LocationServiceTest : DescribeSpec(
             context("존재하는 ID의 위치를 수정하면") {
                 val request =
                     LocationModifyRequest(
-                        _name = MODIFIED_LOCATION_NAME,
+                        name = MODIFIED_LOCATION_NAME,
                     )
                 it("위치가 수정되고, 수정된 위치가 조회되어야 한다.") {
                     val response = locationService.modifyLocation(LOCATION_ID, request)
@@ -93,7 +93,7 @@ class LocationServiceTest : DescribeSpec(
             context("존재하지 않는 ID의 위치를 수정하면") {
                 val request =
                     LocationModifyRequest(
-                        _name = MODIFIED_LOCATION_NAME,
+                        name = MODIFIED_LOCATION_NAME,
                     )
                 it("NotFoundException(NOT_FOUND_LOCATION_ID) 예외가 발생해야 한다.") {
                     val exception =

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceIntegrationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceIntegrationTest.kt
@@ -1,0 +1,477 @@
+package dnd11th.blooming.api.service.myplant
+
+import dnd11th.blooming.api.dto.myplant.MyPlantQueryCreteria
+import dnd11th.blooming.domain.entity.Alarm
+import dnd11th.blooming.domain.entity.Image
+import dnd11th.blooming.domain.entity.Location
+import dnd11th.blooming.domain.entity.MyPlant
+import dnd11th.blooming.domain.repository.ImageRepository
+import dnd11th.blooming.domain.repository.LocationRepository
+import dnd11th.blooming.domain.repository.MyPlantRepository
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.time.LocalDate
+
+@SpringBootTest
+class MyPlantServiceIntegrationTest : DescribeSpec() {
+    @Autowired
+    lateinit var myPlantService: MyPlantService
+
+    @Autowired
+    lateinit var myPlantRepository: MyPlantRepository
+
+    @Autowired
+    lateinit var imageRepository: ImageRepository
+
+    @Autowired
+    lateinit var locationRepository: LocationRepository
+
+    init {
+        describe("최근생성순 식물 전체 조회") {
+            val location =
+                locationRepository.save(
+                    Location(
+                        name = "장소명",
+                        currentDate = CURRENT_DAY,
+                    ),
+                )
+
+            val recentPlant =
+                myPlantRepository.save(
+                    MyPlant(
+                        scientificName = "학명1",
+                        nickname = "별명1",
+                        startDate = CURRENT_DAY,
+                        lastWateredDate = CURRENT_DAY,
+                        lastFertilizerDate = CURRENT_DAY,
+                        alarm = Alarm(),
+                        currentDate = CURRENT_DAY.minusDays(5),
+                    ).also {
+                        it.setLocationRelation(location)
+                    },
+                )
+
+            val latePlant =
+                myPlantRepository.save(
+                    MyPlant(
+                        scientificName = "학명2",
+                        nickname = "별명2",
+                        startDate = CURRENT_DAY,
+                        lastWateredDate = CURRENT_DAY,
+                        lastFertilizerDate = CURRENT_DAY,
+                        alarm = Alarm(),
+                        currentDate = CURRENT_DAY.minusDays(10),
+                    ).also {
+                        it.setLocationRelation(location)
+                    },
+                )
+
+            val image1 =
+                imageRepository.save(
+                    Image(
+                        url = "url1",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image2 =
+                imageRepository.save(
+                    Image(
+                        url = "url2",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image3 =
+                imageRepository.save(
+                    Image(
+                        url = "url3",
+                        favorite = false,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image4 =
+                imageRepository.save(
+                    Image(
+                        url = "url4",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(latePlant)
+                    },
+                )
+
+            val image5 =
+                imageRepository.save(
+                    Image(
+                        url = "url5",
+                        favorite = false,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(latePlant)
+                    },
+                )
+            context("식물 전체 조회를 하면") {
+                val result =
+                    myPlantService.findAllMyPlant(
+                        now = CURRENT_DAY,
+                        locationId = location.id,
+                        sort = MyPlantQueryCreteria.CreatedDesc,
+                    )
+
+                it("식물 정보와 인삿말과 imageUrl이 잘 조회된다.") {
+                    result.size shouldBe 2
+                    result[0].nickname shouldBe recentPlant.nickname
+                    result[0].imageUrl shouldBe image1.url
+                    result[1].nickname shouldBe latePlant.nickname
+                    result[1].imageUrl shouldBe image4.url
+                }
+            }
+        }
+        describe("오래된 생성순 식물 전체 조회") {
+            val location =
+                locationRepository.save(
+                    Location(
+                        name = "장소명",
+                        currentDate = CURRENT_DAY,
+                    ),
+                )
+
+            val recentPlant =
+                myPlantRepository.save(
+                    MyPlant(
+                        scientificName = "학명1",
+                        nickname = "별명1",
+                        startDate = CURRENT_DAY,
+                        lastWateredDate = CURRENT_DAY,
+                        lastFertilizerDate = CURRENT_DAY,
+                        alarm = Alarm(),
+                        currentDate = CURRENT_DAY.minusDays(5),
+                    ).also {
+                        it.setLocationRelation(location)
+                    },
+                )
+
+            val latePlant =
+                myPlantRepository.save(
+                    MyPlant(
+                        scientificName = "학명2",
+                        nickname = "별명2",
+                        startDate = CURRENT_DAY,
+                        lastWateredDate = CURRENT_DAY,
+                        lastFertilizerDate = CURRENT_DAY,
+                        alarm = Alarm(),
+                        currentDate = CURRENT_DAY.minusDays(10),
+                    ).also {
+                        it.setLocationRelation(location)
+                    },
+                )
+
+            val image1 =
+                imageRepository.save(
+                    Image(
+                        url = "url1",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image2 =
+                imageRepository.save(
+                    Image(
+                        url = "url2",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image3 =
+                imageRepository.save(
+                    Image(
+                        url = "url3",
+                        favorite = false,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image4 =
+                imageRepository.save(
+                    Image(
+                        url = "url4",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(latePlant)
+                    },
+                )
+
+            val image5 =
+                imageRepository.save(
+                    Image(
+                        url = "url5",
+                        favorite = false,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(latePlant)
+                    },
+                )
+            context("식물 전체 조회를 하면") {
+                val result =
+                    myPlantService.findAllMyPlant(
+                        now = CURRENT_DAY,
+                        locationId = location.id,
+                        sort = MyPlantQueryCreteria.CreatedAsc,
+                    )
+
+                it("식물 정보와 인삿말과 imageUrl이 잘 조회된다.") {
+                    result.size shouldBe 2
+                    result[0].nickname shouldBe latePlant.nickname
+                    result[0].imageUrl shouldBe image4.url
+                    result[1].nickname shouldBe recentPlant.nickname
+                    result[1].imageUrl shouldBe image1.url
+                }
+            }
+        }
+        describe("최근 물주기순 식물 전체 조회") {
+            val location =
+                locationRepository.save(
+                    Location(
+                        name = "장소명",
+                        currentDate = CURRENT_DAY,
+                    ),
+                )
+
+            val recentPlant =
+                myPlantRepository.save(
+                    MyPlant(
+                        scientificName = "학명1",
+                        nickname = "별명1",
+                        startDate = CURRENT_DAY,
+                        lastWateredDate = CURRENT_DAY.minusDays(5),
+                        lastFertilizerDate = CURRENT_DAY,
+                        alarm = Alarm(),
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setLocationRelation(location)
+                    },
+                )
+
+            val latePlant =
+                myPlantRepository.save(
+                    MyPlant(
+                        scientificName = "학명2",
+                        nickname = "별명2",
+                        startDate = CURRENT_DAY,
+                        lastWateredDate = CURRENT_DAY.minusDays(10),
+                        lastFertilizerDate = CURRENT_DAY,
+                        alarm = Alarm(),
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setLocationRelation(location)
+                    },
+                )
+
+            val image1 =
+                imageRepository.save(
+                    Image(
+                        url = "url1",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image2 =
+                imageRepository.save(
+                    Image(
+                        url = "url2",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image3 =
+                imageRepository.save(
+                    Image(
+                        url = "url3",
+                        favorite = false,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image4 =
+                imageRepository.save(
+                    Image(
+                        url = "url4",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(latePlant)
+                    },
+                )
+
+            val image5 =
+                imageRepository.save(
+                    Image(
+                        url = "url5",
+                        favorite = false,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(latePlant)
+                    },
+                )
+            context("식물 전체 조회를 하면") {
+                val result =
+                    myPlantService.findAllMyPlant(
+                        now = CURRENT_DAY,
+                        locationId = location.id,
+                        sort = MyPlantQueryCreteria.WateredDesc,
+                    )
+
+                it("식물 정보와 인삿말과 imageUrl이 잘 조회된다.") {
+                    result.size shouldBe 2
+                    result[0].nickname shouldBe recentPlant.nickname
+                    result[0].imageUrl shouldBe image1.url
+                    result[1].nickname shouldBe latePlant.nickname
+                    result[1].imageUrl shouldBe image4.url
+                }
+            }
+        }
+        describe("오래된 물주기순 식물 전체 조회") {
+            val location =
+                locationRepository.save(
+                    Location(
+                        name = "장소명",
+                        currentDate = CURRENT_DAY,
+                    ),
+                )
+
+            val recentPlant =
+                myPlantRepository.save(
+                    MyPlant(
+                        scientificName = "학명1",
+                        nickname = "별명1",
+                        startDate = CURRENT_DAY,
+                        lastWateredDate = CURRENT_DAY.minusDays(5),
+                        lastFertilizerDate = CURRENT_DAY,
+                        alarm = Alarm(),
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setLocationRelation(location)
+                    },
+                )
+
+            val latePlant =
+                myPlantRepository.save(
+                    MyPlant(
+                        scientificName = "학명2",
+                        nickname = "별명2",
+                        startDate = CURRENT_DAY,
+                        lastWateredDate = CURRENT_DAY.minusDays(10),
+                        lastFertilizerDate = CURRENT_DAY,
+                        alarm = Alarm(),
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setLocationRelation(location)
+                    },
+                )
+
+            val image1 =
+                imageRepository.save(
+                    Image(
+                        url = "url1",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image2 =
+                imageRepository.save(
+                    Image(
+                        url = "url2",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image3 =
+                imageRepository.save(
+                    Image(
+                        url = "url3",
+                        favorite = false,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image4 =
+                imageRepository.save(
+                    Image(
+                        url = "url4",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(latePlant)
+                    },
+                )
+
+            val image5 =
+                imageRepository.save(
+                    Image(
+                        url = "url5",
+                        favorite = false,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(latePlant)
+                    },
+                )
+            context("식물 전체 조회를 하면") {
+                val result =
+                    myPlantService.findAllMyPlant(
+                        now = CURRENT_DAY,
+                        locationId = location.id,
+                        sort = MyPlantQueryCreteria.WateredAsc,
+                    )
+
+                it("식물 정보와 인삿말과 imageUrl이 잘 조회된다.") {
+                    result.size shouldBe 2
+                    result[0].nickname shouldBe latePlant.nickname
+                    result[0].imageUrl shouldBe image4.url
+                    result[1].nickname shouldBe recentPlant.nickname
+                    result[1].imageUrl shouldBe image1.url
+                }
+            }
+        }
+    }
+
+    companion object {
+        val CURRENT_DAY: LocalDate = LocalDate.of(2000, 5, 17)
+    }
+}

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceIntegrationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceIntegrationTest.kt
@@ -29,6 +29,12 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
     lateinit var locationRepository: LocationRepository
 
     init {
+        afterTest {
+            imageRepository.deleteAllInBatch()
+            myPlantRepository.deleteAllInBatch()
+            locationRepository.deleteAllInBatch()
+        }
+
         describe("최근생성순 식물 전체 조회") {
             val location =
                 locationRepository.save(

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceIntegrationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceIntegrationTest.kt
@@ -85,27 +85,25 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     },
                 )
 
-            val image2 =
-                imageRepository.save(
-                    Image(
-                        url = "url2",
-                        favorite = true,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(recentPlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url2",
+                    favorite = true,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(recentPlant)
+                },
+            )
 
-            val image3 =
-                imageRepository.save(
-                    Image(
-                        url = "url3",
-                        favorite = false,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(recentPlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url3",
+                    favorite = false,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(recentPlant)
+                },
+            )
 
             val image4 =
                 imageRepository.save(
@@ -118,16 +116,15 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     },
                 )
 
-            val image5 =
-                imageRepository.save(
-                    Image(
-                        url = "url5",
-                        favorite = false,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(latePlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url5",
+                    favorite = false,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(latePlant)
+                },
+            )
             context("식물 전체 조회를 하면") {
                 val result =
                     myPlantService.findAllMyPlant(
@@ -195,27 +192,25 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     },
                 )
 
-            val image2 =
-                imageRepository.save(
-                    Image(
-                        url = "url2",
-                        favorite = true,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(recentPlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url2",
+                    favorite = true,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(recentPlant)
+                },
+            )
 
-            val image3 =
-                imageRepository.save(
-                    Image(
-                        url = "url3",
-                        favorite = false,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(recentPlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url3",
+                    favorite = false,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(recentPlant)
+                },
+            )
 
             val image4 =
                 imageRepository.save(
@@ -228,16 +223,15 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     },
                 )
 
-            val image5 =
-                imageRepository.save(
-                    Image(
-                        url = "url5",
-                        favorite = false,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(latePlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url5",
+                    favorite = false,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(latePlant)
+                },
+            )
             context("식물 전체 조회를 하면") {
                 val result =
                     myPlantService.findAllMyPlant(
@@ -305,27 +299,25 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     },
                 )
 
-            val image2 =
-                imageRepository.save(
-                    Image(
-                        url = "url2",
-                        favorite = true,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(recentPlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url2",
+                    favorite = true,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(recentPlant)
+                },
+            )
 
-            val image3 =
-                imageRepository.save(
-                    Image(
-                        url = "url3",
-                        favorite = false,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(recentPlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url3",
+                    favorite = false,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(recentPlant)
+                },
+            )
 
             val image4 =
                 imageRepository.save(
@@ -338,16 +330,15 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     },
                 )
 
-            val image5 =
-                imageRepository.save(
-                    Image(
-                        url = "url5",
-                        favorite = false,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(latePlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url5",
+                    favorite = false,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(latePlant)
+                },
+            )
             context("식물 전체 조회를 하면") {
                 val result =
                     myPlantService.findAllMyPlant(
@@ -415,27 +406,25 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     },
                 )
 
-            val image2 =
-                imageRepository.save(
-                    Image(
-                        url = "url2",
-                        favorite = true,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(recentPlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url2",
+                    favorite = true,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(recentPlant)
+                },
+            )
 
-            val image3 =
-                imageRepository.save(
-                    Image(
-                        url = "url3",
-                        favorite = false,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(recentPlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url3",
+                    favorite = false,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(recentPlant)
+                },
+            )
 
             val image4 =
                 imageRepository.save(
@@ -448,16 +437,15 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     },
                 )
 
-            val image5 =
-                imageRepository.save(
-                    Image(
-                        url = "url5",
-                        favorite = false,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(latePlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url5",
+                    favorite = false,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(latePlant)
+                },
+            )
             context("식물 전체 조회를 하면") {
                 val result =
                     myPlantService.findAllMyPlant(

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
@@ -43,14 +43,14 @@ class MyPlantServiceTest : DescribeSpec(
                     lastWateredDate = LAST_WATERED_DATE,
                     alarm = ALARM,
                 ).apply {
-                    id = PLANT_ID
+                    id = MYPLANT_ID
                 }
             every { locationRepository.findByIdOrNull(any()) } returns
                 LOCATION1
             context("정상 요청으로 내 식물을 저장하면") {
                 val request =
                     MyPlantSaveRequest(
-                        scientificName = SCIENTIFIC_NAME,
+                        plantId = PLANT_ID,
                         nickname = NICKNAME,
                         locationId = LOCATION_ID,
                         startDate = START_DATE,
@@ -65,7 +65,7 @@ class MyPlantServiceTest : DescribeSpec(
                 it("정상적으로 저장되고 예외가 발생하면 안된다.") {
                     val result = myPlantService.saveMyPlant(request)
 
-                    result.myPlantId shouldBe PLANT_ID
+                    result.myPlantId shouldBe MYPLANT_ID
                     result.message shouldBe "등록 되었습니다."
                 }
             }
@@ -193,7 +193,7 @@ class MyPlantServiceTest : DescribeSpec(
         }
 
         describe("내 식물 상세 조회") {
-            every { myPlantRepsitory.findByIdOrNull(PLANT_ID) } returns
+            every { myPlantRepsitory.findByIdOrNull(MYPLANT_ID) } returns
                 MyPlant(
                     scientificName = SCIENTIFIC_NAME,
                     nickname = NICKNAME,
@@ -201,7 +201,7 @@ class MyPlantServiceTest : DescribeSpec(
                     lastWateredDate = LAST_WATERED_DATE,
                     alarm = ALARM,
                 ).apply {
-                    id = PLANT_ID
+                    id = MYPLANT_ID
                 }
             every { imageRepository.findAllByMyPlant(any()) } returns
                 listOf(
@@ -225,11 +225,11 @@ class MyPlantServiceTest : DescribeSpec(
                 FERTILIZER_TITLE
             every { myPlantMessageFactory.createFertilizerInfo(any(), any()) } returns
                 FERTILIZER_INFO
-            every { myPlantRepsitory.findByIdOrNull(not(eq(PLANT_ID))) } returns
+            every { myPlantRepsitory.findByIdOrNull(not(eq(MYPLANT_ID))) } returns
                 null
             context("존재하는 ID로 상세 조회하면") {
                 it("내 식물의 상세 정보가 조회되어야 한다.") {
-                    val response = myPlantService.findMyPlantDetail(PLANT_ID, CURRENT_DAY)
+                    val response = myPlantService.findMyPlantDetail(MYPLANT_ID, CURRENT_DAY)
                     response.nickname shouldBe NICKNAME
                     response.scientificName shouldBe SCIENTIFIC_NAME
                     response.startDate shouldBe START_DATE
@@ -246,7 +246,7 @@ class MyPlantServiceTest : DescribeSpec(
                 it("NotFoundException(NOT_FOUND_MYPLANT_ID) 예외가 발생해야 한다.") {
                     val exception =
                         shouldThrow<NotFoundException> {
-                            myPlantService.findMyPlantDetail(PLANT_ID2, CURRENT_DAY)
+                            myPlantService.findMyPlantDetail(MYPLANT_ID2, CURRENT_DAY)
                         }
                     exception.message shouldBe "존재하지 않는 내 식물입니다."
                     exception.errorType shouldBe ErrorType.NOT_FOUND_MYPLANT
@@ -264,7 +264,7 @@ class MyPlantServiceTest : DescribeSpec(
                     lastFertilizerDate = LAST_FERTILIZER_DATE,
                     alarm = ALARM,
                 )
-            every { myPlantRepsitory.findByIdOrNull(not(eq(PLANT_ID))) } returns
+            every { myPlantRepsitory.findByIdOrNull(not(eq(MYPLANT_ID))) } returns
                 null
             every { locationRepository.findByName(any()) } returns
                 Location(
@@ -282,7 +282,7 @@ class MyPlantServiceTest : DescribeSpec(
                         lastFertilizerDate = LAST_FERTILIZER_DATE,
                     )
                 it("정상 흐름을 반환해야 한다.") {
-                    myPlantService.modifyMyPlant(PLANT_ID, request)
+                    myPlantService.modifyMyPlant(MYPLANT_ID, request)
                 }
             }
             context("존재하지 않는 내 식물 ID로 수정하면") {
@@ -296,7 +296,7 @@ class MyPlantServiceTest : DescribeSpec(
                     )
                 it("NotFoundException(NOT_FOUND_MYPLANT_ID) 예외가 발생해야 한다.") {
                     val exception =
-                        shouldThrow<NotFoundException> { myPlantService.modifyMyPlant(PLANT_ID2, request) }
+                        shouldThrow<NotFoundException> { myPlantService.modifyMyPlant(MYPLANT_ID2, request) }
                     exception.message shouldBe "존재하지 않는 내 식물입니다."
                     exception.errorType shouldBe ErrorType.NOT_FOUND_MYPLANT
                 }
@@ -312,7 +312,7 @@ class MyPlantServiceTest : DescribeSpec(
                     )
                 it("NotFoundException(NOT_FOUND_LOCATION_ID) 예외가 발생해야 한다.") {
                     val exception =
-                        shouldThrow<NotFoundException> { myPlantService.modifyMyPlant(PLANT_ID, request) }
+                        shouldThrow<NotFoundException> { myPlantService.modifyMyPlant(MYPLANT_ID, request) }
                     exception.message shouldBe "존재하지 않는 위치입니다."
                     exception.errorType shouldBe ErrorType.NOT_FOUND_LOCATION
                 }
@@ -320,7 +320,7 @@ class MyPlantServiceTest : DescribeSpec(
         }
 
         describe("내 식물 삭제") {
-            every { myPlantRepsitory.findByIdOrNull(PLANT_ID) } returns
+            every { myPlantRepsitory.findByIdOrNull(MYPLANT_ID) } returns
                 MyPlant(
                     scientificName = SCIENTIFIC_NAME,
                     nickname = NICKNAME,
@@ -328,22 +328,22 @@ class MyPlantServiceTest : DescribeSpec(
                     lastWateredDate = LAST_WATERED_DATE,
                     alarm = ALARM,
                 ).apply {
-                    id = PLANT_ID
+                    id = MYPLANT_ID
                 }
-            every { myPlantRepsitory.findByIdOrNull(not(eq(PLANT_ID))) } returns
+            every { myPlantRepsitory.findByIdOrNull(not(eq(MYPLANT_ID))) } returns
                 null
             every { myPlantRepsitory.delete(any()) } just runs
             every { imageRepository.deleteAllInBatchByMyPlant(any()) } just runs
 
             context("정상 요청으로 삭제하면") {
                 it("정상 흐름이 반환되어야 한다.") {
-                    myPlantService.deleteMyPlant(PLANT_ID)
+                    myPlantService.deleteMyPlant(MYPLANT_ID)
                 }
             }
             context("존재하지 않는 내 식물 ID로 삭제하면") {
                 it("NotFoundException(NOT_FOUND_MYPLANT_ID) 예외가 발생해야 한다.") {
                     val exception =
-                        shouldThrow<NotFoundException> { myPlantService.deleteMyPlant(PLANT_ID2) }
+                        shouldThrow<NotFoundException> { myPlantService.deleteMyPlant(MYPLANT_ID2) }
                     exception.message shouldBe "존재하지 않는 내 식물입니다."
                     exception.errorType shouldBe ErrorType.NOT_FOUND_MYPLANT
                 }
@@ -351,7 +351,7 @@ class MyPlantServiceTest : DescribeSpec(
         }
 
         describe("내 식물 물주기") {
-            every { myPlantRepsitory.findByIdOrNull(PLANT_ID) } returns
+            every { myPlantRepsitory.findByIdOrNull(MYPLANT_ID) } returns
                 MyPlant(
                     scientificName = SCIENTIFIC_NAME,
                     nickname = NICKNAME,
@@ -359,14 +359,14 @@ class MyPlantServiceTest : DescribeSpec(
                     lastWateredDate = LAST_WATERED_DATE,
                     alarm = ALARM,
                 ).apply {
-                    id = PLANT_ID
+                    id = MYPLANT_ID
                 }
-            every { myPlantRepsitory.findByIdOrNull(not(eq(PLANT_ID))) } returns
+            every { myPlantRepsitory.findByIdOrNull(not(eq(MYPLANT_ID))) } returns
                 null
             context("존재하는 내 식물 ID로 내 식물 물주기 요청하면") {
                 it("정상 흐름이 반환된다.") {
                     shouldNotThrowAny {
-                        myPlantService.waterMyPlant(PLANT_ID, CURRENT_DAY)
+                        myPlantService.waterMyPlant(MYPLANT_ID, CURRENT_DAY)
                     }
                 }
             }
@@ -374,7 +374,7 @@ class MyPlantServiceTest : DescribeSpec(
                 it("NotFoundException(NOT_FOUND_MYPLANT_ID) 예외가 발생해야 한다.") {
                     val exception =
                         shouldThrow<NotFoundException> {
-                            myPlantService.waterMyPlant(PLANT_ID2, CURRENT_DAY)
+                            myPlantService.waterMyPlant(MYPLANT_ID2, CURRENT_DAY)
                         }
                     exception.message shouldBe "존재하지 않는 내 식물입니다."
                     exception.errorType shouldBe ErrorType.NOT_FOUND_MYPLANT
@@ -383,7 +383,7 @@ class MyPlantServiceTest : DescribeSpec(
         }
 
         describe("내 식물 비료주기") {
-            every { myPlantRepsitory.findByIdOrNull(PLANT_ID) } returns
+            every { myPlantRepsitory.findByIdOrNull(MYPLANT_ID) } returns
                 MyPlant(
                     scientificName = SCIENTIFIC_NAME,
                     nickname = NICKNAME,
@@ -391,14 +391,14 @@ class MyPlantServiceTest : DescribeSpec(
                     lastWateredDate = LAST_WATERED_DATE,
                     alarm = ALARM,
                 ).apply {
-                    id = PLANT_ID
+                    id = MYPLANT_ID
                 }
-            every { myPlantRepsitory.findByIdOrNull(not(eq(PLANT_ID))) } returns
+            every { myPlantRepsitory.findByIdOrNull(not(eq(MYPLANT_ID))) } returns
                 null
             context("존재하는 내 식물 ID로 내 식물 비료주기 요청하면") {
                 it("정상 흐름이 반환된다.") {
                     shouldNotThrowAny {
-                        myPlantService.fertilizerMyPlant(PLANT_ID, CURRENT_DAY)
+                        myPlantService.fertilizerMyPlant(MYPLANT_ID, CURRENT_DAY)
                     }
                 }
             }
@@ -406,7 +406,7 @@ class MyPlantServiceTest : DescribeSpec(
                 it("NotFoundException(NOT_FOUND_MYPLANT_ID) 예외가 발생해야 한다.") {
                     val exception =
                         shouldThrow<NotFoundException> {
-                            myPlantService.fertilizerMyPlant(PLANT_ID2, CURRENT_DAY)
+                            myPlantService.fertilizerMyPlant(MYPLANT_ID2, CURRENT_DAY)
                         }
                     exception.message shouldBe "존재하지 않는 내 식물입니다."
                     exception.errorType shouldBe ErrorType.NOT_FOUND_MYPLANT
@@ -415,7 +415,7 @@ class MyPlantServiceTest : DescribeSpec(
         }
 
         describe("내 식물 건강확인 알림 변경") {
-            every { myPlantRepsitory.findByIdOrNull(PLANT_ID) } returns
+            every { myPlantRepsitory.findByIdOrNull(MYPLANT_ID) } returns
                 MyPlant(
                     scientificName = SCIENTIFIC_NAME,
                     nickname = NICKNAME,
@@ -423,9 +423,9 @@ class MyPlantServiceTest : DescribeSpec(
                     lastWateredDate = LAST_WATERED_DATE,
                     alarm = ALARM,
                 ).apply {
-                    id = PLANT_ID
+                    id = MYPLANT_ID
                 }
-            every { myPlantRepsitory.findByIdOrNull(not(eq(PLANT_ID))) } returns
+            every { myPlantRepsitory.findByIdOrNull(not(eq(MYPLANT_ID))) } returns
                 null
             context("존재하는 내 식물 ID로 내 식물 비료주기 요청하면") {
                 val request =
@@ -434,7 +434,7 @@ class MyPlantServiceTest : DescribeSpec(
                     )
                 it("정상 흐름이 반환된다.") {
                     shouldNotThrowAny {
-                        myPlantService.modifyMyPlantHealthCheck(PLANT_ID, request)
+                        myPlantService.modifyMyPlantHealthCheck(MYPLANT_ID, request)
                     }
                 }
             }
@@ -446,7 +446,7 @@ class MyPlantServiceTest : DescribeSpec(
                 it("NotFoundException(NOT_FOUND_MYPLANT_ID) 예외가 발생해야 한다.") {
                     val exception =
                         shouldThrow<NotFoundException> {
-                            myPlantService.modifyMyPlantHealthCheck(PLANT_ID2, request)
+                            myPlantService.modifyMyPlantHealthCheck(MYPLANT_ID2, request)
                         }
                     exception.message shouldBe "존재하지 않는 내 식물입니다."
                     exception.errorType shouldBe ErrorType.NOT_FOUND_MYPLANT
@@ -455,7 +455,7 @@ class MyPlantServiceTest : DescribeSpec(
         }
 
         describe("알림 변경") {
-            every { myPlantRepsitory.findByIdOrNull(PLANT_ID) } returns
+            every { myPlantRepsitory.findByIdOrNull(MYPLANT_ID) } returns
                 MyPlant(
                     scientificName = SCIENTIFIC_NAME,
                     nickname = NICKNAME,
@@ -463,9 +463,9 @@ class MyPlantServiceTest : DescribeSpec(
                     lastWateredDate = LAST_WATERED_DATE,
                     alarm = ALARM,
                 ).apply {
-                    id = PLANT_ID
+                    id = MYPLANT_ID
                 }
-            every { myPlantRepsitory.findByIdOrNull(not(eq(PLANT_ID))) } returns
+            every { myPlantRepsitory.findByIdOrNull(not(eq(MYPLANT_ID))) } returns
                 null
             context("존재하는 ID와 요청으로 알림 변경 요청을 하면") {
                 val request =
@@ -477,7 +477,7 @@ class MyPlantServiceTest : DescribeSpec(
                         healthCheckAlarm = HEALTHCHECK_ALARM,
                     )
                 it("알림 정보가 변경되어야 한다.") {
-                    myPlantService.modifyMyPlantAlarm(PLANT_ID, request)
+                    myPlantService.modifyMyPlantAlarm(MYPLANT_ID, request)
                 }
             }
             context("존재하지 않는 ID와 요청으로 알림 변경 요청을 하면") {
@@ -492,7 +492,7 @@ class MyPlantServiceTest : DescribeSpec(
                 it("NotFoundException(NOT_FOUND_MYPLANT_ID) 예외가 발생해야 한다.") {
                     val exception =
                         shouldThrow<NotFoundException> {
-                            myPlantService.modifyMyPlantAlarm(PLANT_ID2, request)
+                            myPlantService.modifyMyPlantAlarm(MYPLANT_ID2, request)
                         }
                     exception.message shouldBe "존재하지 않는 내 식물입니다."
                     exception.errorType shouldBe ErrorType.NOT_FOUND_MYPLANT
@@ -506,6 +506,7 @@ class MyPlantServiceTest : DescribeSpec(
         val FUTURE_DATE: LocalDate = CURRENT_DAY.plusDays(1)
 
         const val PLANT_ID = 1L
+        const val MYPLANT_ID = 1L
         const val LOCATION_ID = 100L
         const val SCIENTIFIC_NAME = "몬스테라 델리오사"
         const val NICKNAME = "뿡뿡이"
@@ -513,7 +514,7 @@ class MyPlantServiceTest : DescribeSpec(
         val START_DATE: LocalDate = CURRENT_DAY.minusDays(1)
         val LAST_WATERED_DATE: LocalDate = CURRENT_DAY.minusDays(1)
         val LAST_FERTILIZER_DATE: LocalDate = CURRENT_DAY.minusDays(1)
-        const val PLANT_ID2 = 2L
+        const val MYPLANT_ID2 = 2L
 
         const val SCIENTIFIC_NAME2 = "병아리 눈물"
         const val NICKNAME2 = "빵빵이"

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
@@ -395,7 +395,7 @@ class MyPlantServiceTest : DescribeSpec(
             context("존재하는 내 식물 ID로 내 식물 비료주기 요청하면") {
                 val request =
                     MyPlantHealthCheckRequest(
-                        healthCheck = true,
+                        _healthCheck = true,
                     )
                 it("정상 흐름이 반환된다.") {
                     shouldNotThrowAny {
@@ -406,7 +406,7 @@ class MyPlantServiceTest : DescribeSpec(
             context("존재하지 않는 내 식물 ID로 내 식물 비료주기 요청하면") {
                 val request =
                     MyPlantHealthCheckRequest(
-                        healthCheck = true,
+                        _healthCheck = true,
                     )
                 it("NotFoundException(NOT_FOUND_MYPLANT_ID) 예외가 발생해야 한다.") {
                     val exception =

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
@@ -6,7 +6,6 @@ import dnd11th.blooming.api.dto.myplant.MyPlantModifyRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantQueryCreteria
 import dnd11th.blooming.api.dto.myplant.MyPlantSaveRequest
 import dnd11th.blooming.common.exception.ErrorType
-import dnd11th.blooming.common.exception.InvalidDateException
 import dnd11th.blooming.common.exception.NotFoundException
 import dnd11th.blooming.domain.entity.Alarm
 import dnd11th.blooming.domain.entity.Image
@@ -64,82 +63,10 @@ class MyPlantServiceTest : DescribeSpec(
                         healthCheckAlarm = HEALTHCHECK_ALARM,
                     )
                 it("정상적으로 저장되고 예외가 발생하면 안된다.") {
-                    val result = myPlantService.saveMyPlant(request, CURRENT_DAY)
+                    val result = myPlantService.saveMyPlant(request)
 
                     result.myPlantId shouldBe PLANT_ID
                     result.message shouldBe "등록 되었습니다."
-                }
-            }
-            context("시작날짜가 미래인 요청으로 내 식물을 저장하면") {
-                val request =
-                    MyPlantSaveRequest(
-                        scientificName = SCIENTIFIC_NAME,
-                        nickname = NICKNAME,
-                        locationId = LOCATION_ID,
-                        startDate = FUTURE_DATE,
-                        lastWateredDate = LAST_WATERED_DATE,
-                        lastFertilizerDate = LAST_FERTILIZER_DATE,
-                        waterAlarm = WATER_ALARM,
-                        waterPeriod = WATER_PERIOD,
-                        fertilizerAlarm = FERTILIZER_ALARM,
-                        fertilizerPeriod = FERTILIZER_PERIOD,
-                        healthCheckAlarm = HEALTHCHECK_ALARM,
-                    )
-                it("InvalidDateException 예외가 발생해야 한다.") {
-                    val exception =
-                        shouldThrow<InvalidDateException> {
-                            myPlantService.saveMyPlant(request, CURRENT_DAY)
-                        }
-                    exception.message shouldBe "올바르지 않은 날짜입니다."
-                    exception.errorType shouldBe ErrorType.INVALID_DATE
-                }
-            }
-            context("마지막으로 물 준 날짜가 미래인 요청으로 내 식물을 저장하면") {
-                val request =
-                    MyPlantSaveRequest(
-                        scientificName = SCIENTIFIC_NAME,
-                        nickname = NICKNAME,
-                        locationId = LOCATION_ID,
-                        startDate = START_DATE,
-                        lastWateredDate = FUTURE_DATE,
-                        lastFertilizerDate = LAST_FERTILIZER_DATE,
-                        waterAlarm = WATER_ALARM,
-                        waterPeriod = WATER_PERIOD,
-                        fertilizerAlarm = FERTILIZER_ALARM,
-                        fertilizerPeriod = FERTILIZER_PERIOD,
-                        healthCheckAlarm = HEALTHCHECK_ALARM,
-                    )
-                it("InvalidDateException 예외가 발생해야 한다.") {
-                    val exception =
-                        shouldThrow<InvalidDateException> {
-                            myPlantService.saveMyPlant(request, CURRENT_DAY)
-                        }
-                    exception.message shouldBe "올바르지 않은 날짜입니다."
-                    exception.errorType shouldBe ErrorType.INVALID_DATE
-                }
-            }
-            context("마지막으로 비료 준 날짜가 미래인 요청으로 내 식물을 저장하면") {
-                val request =
-                    MyPlantSaveRequest(
-                        scientificName = SCIENTIFIC_NAME,
-                        nickname = NICKNAME,
-                        locationId = LOCATION_ID,
-                        startDate = START_DATE,
-                        lastWateredDate = LAST_WATERED_DATE,
-                        lastFertilizerDate = FUTURE_DATE,
-                        waterAlarm = WATER_ALARM,
-                        waterPeriod = WATER_PERIOD,
-                        fertilizerAlarm = FERTILIZER_ALARM,
-                        fertilizerPeriod = FERTILIZER_PERIOD,
-                        healthCheckAlarm = HEALTHCHECK_ALARM,
-                    )
-                it("InvalidDateException 예외가 발생해야 한다.") {
-                    val exception =
-                        shouldThrow<InvalidDateException> {
-                            myPlantService.saveMyPlant(request, CURRENT_DAY)
-                        }
-                    exception.message shouldBe "올바르지 않은 날짜입니다."
-                    exception.errorType shouldBe ErrorType.INVALID_DATE
                 }
             }
         }

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
@@ -63,7 +63,7 @@ class MyPlantServiceTest : DescribeSpec(
                         healthCheckAlarm = HEALTHCHECK_ALARM,
                     )
                 it("정상적으로 저장되고 예외가 발생하면 안된다.") {
-                    val result = myPlantService.saveMyPlant(request)
+                    val result = myPlantService.saveMyPlant(request, CURRENT_DAY)
 
                     result.myPlantId shouldBe MYPLANT_ID
                     result.message shouldBe "등록 되었습니다."

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
@@ -2,8 +2,8 @@ package dnd11th.blooming.api.service.myplant
 
 import dnd11th.blooming.api.dto.myplant.AlarmModifyRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantHealthCheckRequest
+import dnd11th.blooming.api.dto.myplant.MyPlantIdWithImageUrl
 import dnd11th.blooming.api.dto.myplant.MyPlantModifyRequest
-import dnd11th.blooming.api.dto.myplant.MyPlantQueryCreteria
 import dnd11th.blooming.api.dto.myplant.MyPlantSaveRequest
 import dnd11th.blooming.common.exception.ErrorType
 import dnd11th.blooming.common.exception.NotFoundException
@@ -75,7 +75,7 @@ class MyPlantServiceTest : DescribeSpec(
             val myPlant1 =
                 MyPlant(
                     scientificName = "병아리눈물",
-                    nickname = "생성1등 물주기2등",
+                    nickname = "식물1",
                     currentDate = LocalDate.of(2024, 5, 15),
                     lastWateredDate = LocalDate.of(2024, 5, 16),
                     lastFertilizerDate = LocalDate.of(2024, 5, 16),
@@ -87,7 +87,7 @@ class MyPlantServiceTest : DescribeSpec(
             val myPlant2 =
                 MyPlant(
                     scientificName = "몬스테라 델리오사",
-                    nickname = "생성2등 물주기3등",
+                    nickname = "식물2",
                     currentDate = LocalDate.of(2024, 5, 16),
                     lastWateredDate = LocalDate.of(2024, 5, 17),
                     lastFertilizerDate = LocalDate.of(2024, 5, 17),
@@ -99,7 +99,7 @@ class MyPlantServiceTest : DescribeSpec(
             val myPlant3 =
                 MyPlant(
                     scientificName = "선인장",
-                    nickname = "생성3등 물주기1등",
+                    nickname = "식물3",
                     currentDate = LocalDate.of(2024, 5, 17),
                     lastWateredDate = LocalDate.of(2024, 5, 15),
                     lastFertilizerDate = LocalDate.of(2024, 5, 15),
@@ -116,6 +116,12 @@ class MyPlantServiceTest : DescribeSpec(
                 listOf(myPlant3, myPlant1, myPlant2)
             every { myPlantRepsitory.findAllByLocationOrderByLastWateredDateAsc(any()) } returns
                 listOf(myPlant2, myPlant1, myPlant3)
+            every { imageRepository.findFavoriteImagesForMyPlants(any()) } returns
+                listOf(
+                    MyPlantIdWithImageUrl("url1", 1),
+                    MyPlantIdWithImageUrl("url2", 2),
+                    MyPlantIdWithImageUrl("url3", 3),
+                )
             every { locationRepository.findByIdOrNull(any()) } returns
                 null
             every { locationRepository.findByIdOrNull(LOCATION_ID) } returns
@@ -128,66 +134,25 @@ class MyPlantServiceTest : DescribeSpec(
                     response.size shouldBe 3
 
                     response[0].myPlantId shouldBe 1
-                    response[0].nickname shouldBe "생성1등 물주기2등"
+                    response[0].nickname shouldBe "식물1"
+                    response[0].imageUrl shouldBe "url1"
                     response[0].scientificName shouldBe "병아리눈물"
                     response[0].waterRemainDay shouldBe 2
                     response[0].fertilizerRemainDay shouldBe 29
 
                     response[1].myPlantId shouldBe 2
-                    response[1].nickname shouldBe "생성2등 물주기3등"
+                    response[1].nickname shouldBe "식물2"
+                    response[1].imageUrl shouldBe "url2"
                     response[1].scientificName shouldBe "몬스테라 델리오사"
                     response[1].waterRemainDay shouldBe 3
                     response[1].fertilizerRemainDay shouldBe 30
 
                     response[2].myPlantId shouldBe 3
-                    response[2].nickname shouldBe "생성3등 물주기1등"
+                    response[2].nickname shouldBe "식물3"
+                    response[2].imageUrl shouldBe "url3"
                     response[2].scientificName shouldBe "선인장"
                     response[2].waterRemainDay shouldBe 1
                     response[2].fertilizerRemainDay shouldBe 28
-                }
-            }
-            context("내 식물을 최근 등록순으로 전체 조회하면") {
-                it("순서에 맞게 내 식물 리스트가 조회되어야 한다.") {
-                    val response = myPlantService.findAllMyPlant(CURRENT_DAY, null, MyPlantQueryCreteria.CreatedDesc)
-                    response.size shouldBe 3
-                    response[0].nickname shouldBe "생성1등 물주기2등"
-                    response[1].nickname shouldBe "생성2등 물주기3등"
-                    response[2].nickname shouldBe "생성3등 물주기1등"
-                }
-            }
-            context("내 식물을 오래된 등록순으로 전체 조회하면") {
-                it("순서에 맞게 내 식물 리스트가 조회되어야 한다.") {
-                    val response = myPlantService.findAllMyPlant(CURRENT_DAY, null, MyPlantQueryCreteria.CreatedAsc)
-                    response.size shouldBe 3
-                    response[0].nickname shouldBe "생성3등 물주기1등"
-                    response[1].nickname shouldBe "생성2등 물주기3등"
-                    response[2].nickname shouldBe "생성1등 물주기2등"
-                }
-            }
-            context("내 식물을 최근 물 준 순으로 전체 조회하면") {
-                it("순서에 맞게 내 식물 리스트가 조회되어야 한다.") {
-                    val response = myPlantService.findAllMyPlant(CURRENT_DAY, null, MyPlantQueryCreteria.WateredDesc)
-                    response.size shouldBe 3
-                    response[0].nickname shouldBe "생성3등 물주기1등"
-                    response[1].nickname shouldBe "생성1등 물주기2등"
-                    response[2].nickname shouldBe "생성2등 물주기3등"
-                }
-            }
-            context("내 식물을 오래된 물 준 순으로 전체 조회하면") {
-                it("순서에 맞게 내 식물 리스트가 조회되어야 한다.") {
-                    val response = myPlantService.findAllMyPlant(CURRENT_DAY, null, MyPlantQueryCreteria.WateredAsc)
-                    response.size shouldBe 3
-                    response[0].nickname shouldBe "생성2등 물주기3등"
-                    response[1].nickname shouldBe "생성1등 물주기2등"
-                    response[2].nickname shouldBe "생성3등 물주기1등"
-                }
-            }
-            context("내 식물을 locationId를 포함하여 전체 조회하면") {
-                it("해당 location의 식물만이 조회된다.") {
-                    val response = myPlantService.findAllMyPlant(CURRENT_DAY, LOCATION_ID)
-                    response.size shouldBe 2
-                    response[0].nickname shouldBe "생성1등 물주기2등"
-                    response[1].nickname shouldBe "생성2등 물주기3등"
                 }
             }
         }

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
@@ -395,7 +395,7 @@ class MyPlantServiceTest : DescribeSpec(
             context("존재하는 내 식물 ID로 내 식물 비료주기 요청하면") {
                 val request =
                     MyPlantHealthCheckRequest(
-                        _healthCheck = true,
+                        healthCheck = true,
                     )
                 it("정상 흐름이 반환된다.") {
                     shouldNotThrowAny {
@@ -406,7 +406,7 @@ class MyPlantServiceTest : DescribeSpec(
             context("존재하지 않는 내 식물 ID로 내 식물 비료주기 요청하면") {
                 val request =
                     MyPlantHealthCheckRequest(
-                        _healthCheck = true,
+                        healthCheck = true,
                     )
                 it("NotFoundException(NOT_FOUND_MYPLANT_ID) 예외가 발생해야 한다.") {
                     val exception =


### PR DESCRIPTION
> ### How
- spring validation을 추가하였습니다.
- validation 실패시 발생하는 예외에 대하여 전역 예외처리를 추가하였습니다.
- validation이 실제 잘 동작하는지 확인하기 위한 테스트를 작성하였습니다.
- api가 명세서와 다른 부분이 몇개 발견되어, 수정하였습니다.

> ### Result
- validation
  - 이제 요청으로 들어오는 request를 검증할 수 있게 되었습니다.
- api
  - 식물 저장 api의 요청에서 scientificName 대신에 plantId를 받습니다.
  - 식물 전체 조회 api의 응답에서 이제 각 식물의 대표 이미지를 볼 수 있습니다.
  - 식물 전체 조회 api의 경우 계층끼리 잘 작동하는지 확인하기 위해 따로 통합테스트를 진행하였습니다.
