### PR TITLE
[BLOOM-041] validation 추가, api 마이너 수정 #46

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,11 +34,12 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-	runtimeOnly("com.mysql:mysql-connector-j")
-	runtimeOnly("com.h2database:h2")
+    runtimeOnly("com.mysql:mysql-connector-j")
+    runtimeOnly("com.h2database:h2")
 
-	// Validation
-	implementation("org.springframework.boot:spring-boot-starter-validation")
+    // Validation
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("jakarta.validation:jakarta.validation-api:3.1.0")
 
     // Configuration
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,11 +35,10 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     runtimeOnly("com.mysql:mysql-connector-j")
-    runtimeOnly("com.h2database:h2")
+    testImplementation("com.h2database:h2")
 
     // Validation
     implementation("org.springframework.boot:spring-boot-starter-validation")
-    implementation("jakarta.validation:jakarta.validation-api:3.1.0")
 
     // Configuration
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,8 +34,11 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    runtimeOnly("com.mysql:mysql-connector-j")
-    runtimeOnly("com.h2database:h2")
+	runtimeOnly("com.mysql:mysql-connector-j")
+	runtimeOnly("com.h2database:h2")
+
+	// Validation
+	implementation("org.springframework.boot:spring-boot-starter-validation")
 
     // Configuration
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")

--- a/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
@@ -22,7 +22,7 @@ class ImageController(
     override fun saveImage(
         @PathVariable myPlantId: Long,
         @RequestBody @Valid request: ImageSaveRequest,
-    ) = imageService.saveImage(myPlantId, request, LocalDate.now())
+    ) = imageService.saveImage(myPlantId, request.toImageCreateDto(), LocalDate.now())
 
     @PatchMapping("/image/{imageId}")
     override fun modifyFavorite(

--- a/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
@@ -3,6 +3,7 @@ package dnd11th.blooming.api.controller.image
 import dnd11th.blooming.api.dto.image.ImageFavoriteModifyRequest
 import dnd11th.blooming.api.dto.image.ImageSaveRequest
 import dnd11th.blooming.api.service.image.ImageService
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -20,13 +21,13 @@ class ImageController(
     @PostMapping("/{myPlantId}/image")
     override fun saveImage(
         @PathVariable myPlantId: Long,
-        @RequestBody request: ImageSaveRequest,
+        @RequestBody @Valid request: ImageSaveRequest,
     ) = imageService.saveImage(myPlantId, request, LocalDate.now())
 
     @PatchMapping("/image/{imageId}")
     override fun modifyFavorite(
         @PathVariable imageId: Long,
-        @RequestBody request: ImageFavoriteModifyRequest,
+        @RequestBody @Valid request: ImageFavoriteModifyRequest,
     ) = imageService.modifyFavorite(imageId, request)
 
     @DeleteMapping("/image/{imageId}")

--- a/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
@@ -28,7 +28,7 @@ class ImageController(
         @PathVariable imageId: Long,
         @RequestBody @Valid request: ImageFavoriteModifyRequest,
     ) {
-        imageService.modifyFavorite(imageId, request)
+        imageService.modifyFavorite(imageId, request.favorite!!)
     }
 
     @DeleteMapping("/image/{imageId}")

--- a/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
@@ -28,7 +28,10 @@ class ImageController(
     override fun modifyFavorite(
         @PathVariable imageId: Long,
         @RequestBody @Valid request: ImageFavoriteModifyRequest,
-    ) = imageService.modifyFavorite(imageId, request)
+    ) {
+        println(">>>" + request.favorite)
+        imageService.modifyFavorite(imageId, request)
+    }
 
     @DeleteMapping("/image/{imageId}")
     override fun deleteImage(

--- a/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
@@ -29,7 +29,6 @@ class ImageController(
         @PathVariable imageId: Long,
         @RequestBody @Valid request: ImageFavoriteModifyRequest,
     ) {
-        println(">>>" + request.favorite)
         imageService.modifyFavorite(imageId, request)
     }
 

--- a/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.time.LocalDate
 
 @RestController
 @RequestMapping("/api/v1/myplants")
@@ -22,7 +21,7 @@ class ImageController(
     override fun saveImage(
         @PathVariable myPlantId: Long,
         @RequestBody @Valid request: ImageSaveRequest,
-    ) = imageService.saveImage(myPlantId, request.toImageCreateDto(), LocalDate.now())
+    ) = imageService.saveImage(myPlantId, request.toImageCreateDto())
 
     @PatchMapping("/image/{imageId}")
     override fun modifyFavorite(

--- a/src/main/kotlin/dnd11th/blooming/api/controller/location/LocationController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/location/LocationController.kt
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
 
 @RestController
 @RequestMapping("/api/v1/location")
@@ -23,7 +24,7 @@ class LocationController(
     @PostMapping
     override fun saveLocation(
         @RequestBody @Valid request: LocationSaveRequest,
-    ): LocationSaveResponse = locationService.saveLocation(request)
+    ): LocationSaveResponse = locationService.saveLocation(request, LocalDate.now())
 
     @GetMapping
     override fun findAllLocation(): List<LocationResponse> = locationService.findAllLocation()

--- a/src/main/kotlin/dnd11th/blooming/api/controller/location/LocationController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/location/LocationController.kt
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.time.LocalDate
 
 @RestController
 @RequestMapping("/api/v1/location")
@@ -24,7 +23,7 @@ class LocationController(
     @PostMapping
     override fun saveLocation(
         @RequestBody @Valid request: LocationSaveRequest,
-    ): LocationSaveResponse = locationService.saveLocation(request.toLocationCreateDto(), LocalDate.now())
+    ): LocationSaveResponse = locationService.saveLocation(request.toLocationCreateDto())
 
     @GetMapping
     override fun findAllLocation(): List<LocationResponse> = locationService.findAllLocation()

--- a/src/main/kotlin/dnd11th/blooming/api/controller/location/LocationController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/location/LocationController.kt
@@ -5,6 +5,7 @@ import dnd11th.blooming.api.dto.location.LocationResponse
 import dnd11th.blooming.api.dto.location.LocationSaveRequest
 import dnd11th.blooming.api.dto.location.LocationSaveResponse
 import dnd11th.blooming.api.service.location.LocationService
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -21,7 +22,7 @@ class LocationController(
 ) : LocationApi {
     @PostMapping
     override fun saveLocation(
-        @RequestBody request: LocationSaveRequest,
+        @RequestBody @Valid request: LocationSaveRequest,
     ): LocationSaveResponse = locationService.saveLocation(request)
 
     @GetMapping
@@ -30,7 +31,7 @@ class LocationController(
     @PatchMapping("/{locationId}")
     override fun modifyLocation(
         @PathVariable locationId: Long,
-        @RequestBody request: LocationModifyRequest,
+        @RequestBody @Valid request: LocationModifyRequest,
     ): LocationResponse = locationService.modifyLocation(locationId, request)
 
     @DeleteMapping("/{locationId}")

--- a/src/main/kotlin/dnd11th/blooming/api/controller/location/LocationController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/location/LocationController.kt
@@ -24,7 +24,7 @@ class LocationController(
     @PostMapping
     override fun saveLocation(
         @RequestBody @Valid request: LocationSaveRequest,
-    ): LocationSaveResponse = locationService.saveLocation(request, LocalDate.now())
+    ): LocationSaveResponse = locationService.saveLocation(request.toLocationCreateDto(), LocalDate.now())
 
     @GetMapping
     override fun findAllLocation(): List<LocationResponse> = locationService.findAllLocation()

--- a/src/main/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantController.kt
@@ -31,7 +31,7 @@ class MyPlantController(
     @PostMapping
     override fun saveMyPlant(
         @RequestBody @Valid request: MyPlantSaveRequest,
-    ): MyPlantSaveResponse = myPlantService.saveMyPlant(request)
+    ): MyPlantSaveResponse = myPlantService.saveMyPlant(request, LocalDate.now())
 
     @GetMapping
     override fun findAllMyPlant(

--- a/src/main/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantController.kt
@@ -11,6 +11,7 @@ import dnd11th.blooming.api.dto.myplant.MyPlantSaveRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantSaveResponse
 import dnd11th.blooming.api.dto.myplant.MyPlantSortParam
 import dnd11th.blooming.api.service.myplant.MyPlantService
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -29,7 +30,7 @@ class MyPlantController(
 ) : MyPlantApi {
     @PostMapping
     override fun saveMyPlant(
-        @RequestBody request: MyPlantSaveRequest,
+        @RequestBody @Valid request: MyPlantSaveRequest,
     ): MyPlantSaveResponse = myPlantService.saveMyPlant(request, LocalDate.now())
 
     @GetMapping
@@ -48,7 +49,7 @@ class MyPlantController(
     @PatchMapping("/{myPlantId}")
     override fun modifyMyPlant(
         @PathVariable myPlantId: Long,
-        @RequestBody request: MyPlantModifyRequest,
+        @RequestBody @Valid request: MyPlantModifyRequest,
     ) = myPlantService.modifyMyPlant(myPlantId, request)
 
     @DeleteMapping("/{myPlantId}")
@@ -69,12 +70,12 @@ class MyPlantController(
     @PatchMapping("/{myPlantId}/healthcheck")
     override fun modifyMyPlantHealthCheck(
         @PathVariable myPlantId: Long,
-        @RequestBody request: MyPlantHealthCheckRequest,
+        @RequestBody @Valid request: MyPlantHealthCheckRequest,
     ) = myPlantService.modifyMyPlantHealthCheck(myPlantId, request)
 
     @PatchMapping("/{myPlantId}/alarm")
     override fun modifyMyPlantAlarm(
         @PathVariable myPlantId: Long,
-        @RequestBody request: AlarmModifyRequest,
+        @RequestBody @Valid request: AlarmModifyRequest,
     ) = myPlantService.modifyMyPlantAlarm(myPlantId, request)
 }

--- a/src/main/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantController.kt
@@ -31,7 +31,7 @@ class MyPlantController(
     @PostMapping
     override fun saveMyPlant(
         @RequestBody @Valid request: MyPlantSaveRequest,
-    ): MyPlantSaveResponse = myPlantService.saveMyPlant(request, LocalDate.now())
+    ): MyPlantSaveResponse = myPlantService.saveMyPlant(request)
 
     @GetMapping
     override fun findAllMyPlant(

--- a/src/main/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantController.kt
@@ -31,12 +31,7 @@ class MyPlantController(
     @PostMapping
     override fun saveMyPlant(
         @RequestBody @Valid request: MyPlantSaveRequest,
-    ): MyPlantSaveResponse =
-        myPlantService.saveMyPlant(
-            request.toMyPlantCreateDto(),
-            request.locationId!!,
-            LocalDate.now(),
-        )
+    ): MyPlantSaveResponse = myPlantService.saveMyPlant(request.toMyPlantCreateDto(), request.locationId!!)
 
     @GetMapping
     override fun findAllMyPlant(

--- a/src/main/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantController.kt
@@ -31,7 +31,12 @@ class MyPlantController(
     @PostMapping
     override fun saveMyPlant(
         @RequestBody @Valid request: MyPlantSaveRequest,
-    ): MyPlantSaveResponse = myPlantService.saveMyPlant(request, LocalDate.now())
+    ): MyPlantSaveResponse =
+        myPlantService.saveMyPlant(
+            request.toMyPlantCreateDto(),
+            request.locationId!!,
+            LocalDate.now(),
+        )
 
     @GetMapping
     override fun findAllMyPlant(

--- a/src/main/kotlin/dnd11th/blooming/api/controller/user/UserController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/user/UserController.kt
@@ -4,6 +4,7 @@ import dnd11th.blooming.api.dto.user.IdTokenRequest
 import dnd11th.blooming.api.dto.user.TokenResponse
 import dnd11th.blooming.api.service.user.SocialLoginService
 import dnd11th.blooming.domain.entity.user.OauthProvider
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -18,7 +19,7 @@ class UserController(
     @PostMapping("/login/{provider}")
     fun login(
         @PathVariable provider: String,
-        @RequestBody idTokenRequest: IdTokenRequest,
+        @RequestBody @Valid idTokenRequest: IdTokenRequest,
     ): TokenResponse {
         return socialLoginService.socialLogin(OauthProvider.from(provider), idTokenRequest.idToken)
     }

--- a/src/main/kotlin/dnd11th/blooming/api/dto/home/HomeResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/home/HomeResponse.kt
@@ -12,6 +12,7 @@ data class HomeResponse(
     @field:Schema(description = "내 식물 정보 리스트")
     val myPlantInfo: List<MyPlantHomeResponse>,
     // TODO : 식물 일러스트 응답 추가 필요
+    // val illustUrl: String,
 ) {
     companion object {
         fun from(

--- a/src/main/kotlin/dnd11th/blooming/api/dto/home/MyPlantHomeResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/home/MyPlantHomeResponse.kt
@@ -10,7 +10,7 @@ import java.time.LocalDate
 )
 data class MyPlantHomeResponse(
     @field:Schema(description = "내 식물 ID", example = "1")
-    val myPlantId: Long,
+    val myPlantId: Long?,
     @field:Schema(description = "내 식물 별명", example = "뿡뿡이")
     val nickname: String,
     @field:Schema(description = "내 식물 학명", example = "몬스테라 델리오사")

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageCreateDto.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageCreateDto.kt
@@ -1,0 +1,5 @@
+package dnd11th.blooming.api.dto.image
+
+data class ImageCreateDto(
+    val url: String,
+)

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageFavoriteModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageFavoriteModifyRequest.kt
@@ -10,6 +10,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 )
 data class ImageFavoriteModifyRequest(
 	@field:Schema(description = "즐겨찾기 여부", example = "true")
-    @NotNull(message = "즐겨찾기 여부는 필수값입니다.")
+    @field:NotNull(message = "즐겨찾기 여부는 필수값입니다.")
     val favorite: Boolean,
 )

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageFavoriteModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageFavoriteModifyRequest.kt
@@ -1,5 +1,7 @@
 package dnd11th.blooming.api.dto.image
 
+import jakarta.validation.constraints.NotNull
+
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(
@@ -7,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema
     description = "이미지 즐겨찾기 수정 요청",
 )
 data class ImageFavoriteModifyRequest(
-    @field:Schema(description = "즐겨찾기 여부", example = "true")
+	@field:Schema(description = "즐겨찾기 여부", example = "true")
+    @NotNull(message = "즐겨찾기 여부는 필수값입니다.")
     val favorite: Boolean,
 )

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageFavoriteModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageFavoriteModifyRequest.kt
@@ -1,15 +1,14 @@
 package dnd11th.blooming.api.dto.image
 
-import jakarta.validation.constraints.NotNull
-
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
 
 @Schema(
     name = "Image Favorite Modify Request",
     description = "이미지 즐겨찾기 수정 요청",
 )
 data class ImageFavoriteModifyRequest(
-	@field:Schema(description = "즐겨찾기 여부", example = "true")
+    @field:Schema(description = "즐겨찾기 여부", example = "true")
     @field:NotNull(message = "즐겨찾기 여부는 필수값입니다.")
     val favorite: Boolean?,
 )

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageFavoriteModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageFavoriteModifyRequest.kt
@@ -1,6 +1,5 @@
 package dnd11th.blooming.api.dto.image
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotNull
 
 import io.swagger.v3.oas.annotations.media.Schema
@@ -12,9 +11,5 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class ImageFavoriteModifyRequest(
 	@field:Schema(description = "즐겨찾기 여부", example = "true")
     @field:NotNull(message = "즐겨찾기 여부는 필수값입니다.")
-    @JsonProperty("favorite")
-    private val _favorite: Boolean?,
-) {
-    val favorite: Boolean
-        get() = _favorite!!
-}
+    val favorite: Boolean?,
+)

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageFavoriteModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageFavoriteModifyRequest.kt
@@ -1,5 +1,6 @@
 package dnd11th.blooming.api.dto.image
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotNull
 
 import io.swagger.v3.oas.annotations.media.Schema
@@ -11,5 +12,9 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class ImageFavoriteModifyRequest(
 	@field:Schema(description = "즐겨찾기 여부", example = "true")
     @field:NotNull(message = "즐겨찾기 여부는 필수값입니다.")
-    val favorite: Boolean,
-)
+    @JsonProperty("favorite")
+    private val _favorite: Boolean?,
+) {
+    val favorite: Boolean
+        get() = _favorite!!
+}

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageResponse.kt
@@ -21,7 +21,7 @@ data class ImageResponse(
             ImageResponse(
                 imageUrl = image.url,
                 favorite = image.favorite,
-                createdDate = image.createdDate,
+                createdDate = image.createdDate.toLocalDate(),
             )
 
         fun fromList(images: List<Image>): List<ImageResponse> =

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageSaveRequest.kt
@@ -12,20 +12,20 @@ import java.time.LocalDate
     description = "이미지를 저장하는 요청",
 )
 data class ImageSaveRequest(
-	@NotNull(message = "URL은 필수값입니다.")
-	@NotBlank(message = "URL은 비어있을 수 없습니다.")
     @field:Schema(description = "이미지 URL", example = "image.com/17")
+    @field:NotNull(message = "URL은 필수값입니다.")
+    @field:NotBlank(message = "URL은 비어있을 수 없습니다.")
     val imageUrl: String,
 ) {
-	fun toImage(
-		myPlant: MyPlant,
-		now: LocalDate,
-	): Image =
-		Image(
-			url = imageUrl,
-			favorite = false,
-			currentDate = now,
-		).also {
-			it.setMyPlantRelation(myPlant)
-		}
+    fun toImage(
+        myPlant: MyPlant,
+        now: LocalDate,
+    ): Image =
+        Image(
+            url = imageUrl,
+            favorite = false,
+            currentDate = now,
+        ).also {
+            it.setMyPlantRelation(myPlant)
+        }
 }

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageSaveRequest.kt
@@ -1,11 +1,7 @@
 package dnd11th.blooming.api.dto.image
 
-import dnd11th.blooming.domain.entity.Image
-import dnd11th.blooming.domain.entity.MyPlant
-import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
 import io.swagger.v3.oas.annotations.media.Schema
-import java.time.LocalDate
+import jakarta.validation.constraints.NotBlank
 
 @Schema(
     name = "Image Save Request",
@@ -16,15 +12,8 @@ data class ImageSaveRequest(
     @field:NotBlank(message = "URL은 필수값입니다.")
     val imageUrl: String?,
 ) {
-    fun toImage(
-        myPlant: MyPlant,
-        now: LocalDate,
-    ): Image =
-        Image(
+    fun toImageCreateDto(): ImageCreateDto =
+        ImageCreateDto(
             url = imageUrl!!,
-            favorite = false,
-            currentDate = now,
-        ).also {
-            it.setMyPlantRelation(myPlant)
-        }
+        )
 }

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageSaveRequest.kt
@@ -13,8 +13,7 @@ import java.time.LocalDate
 )
 data class ImageSaveRequest(
     @field:Schema(description = "이미지 URL", example = "image.com/17")
-    @field:NotNull(message = "URL은 필수값입니다.")
-    @field:NotBlank(message = "URL은 비어있을 수 없습니다.")
+    @field:NotBlank(message = "URL은 필수값입니다.")
     val imageUrl: String?,
 ) {
     fun toImage(

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageSaveRequest.kt
@@ -15,14 +15,14 @@ data class ImageSaveRequest(
     @field:Schema(description = "이미지 URL", example = "image.com/17")
     @field:NotNull(message = "URL은 필수값입니다.")
     @field:NotBlank(message = "URL은 비어있을 수 없습니다.")
-    val imageUrl: String,
+    val imageUrl: String?,
 ) {
     fun toImage(
         myPlant: MyPlant,
         now: LocalDate,
     ): Image =
         Image(
-            url = imageUrl,
+            url = imageUrl!!,
             favorite = false,
             currentDate = now,
         ).also {

--- a/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageSaveRequest.kt
@@ -2,6 +2,8 @@ package dnd11th.blooming.api.dto.image
 
 import dnd11th.blooming.domain.entity.Image
 import dnd11th.blooming.domain.entity.MyPlant
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
@@ -10,18 +12,20 @@ import java.time.LocalDate
     description = "이미지를 저장하는 요청",
 )
 data class ImageSaveRequest(
+	@NotNull(message = "URL은 필수값입니다.")
+	@NotBlank(message = "URL은 비어있을 수 없습니다.")
     @field:Schema(description = "이미지 URL", example = "image.com/17")
     val imageUrl: String,
 ) {
-    fun toImage(
-        myPlant: MyPlant,
-        now: LocalDate,
-    ): Image =
-        Image(
-            url = imageUrl,
-            favorite = false,
-            currentDate = now,
-        ).also {
-            it.setMyPlantRelation(myPlant)
-        }
+	fun toImage(
+		myPlant: MyPlant,
+		now: LocalDate,
+	): Image =
+		Image(
+			url = imageUrl,
+			favorite = false,
+			currentDate = now,
+		).also {
+			it.setMyPlantRelation(myPlant)
+		}
 }

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationCreateDto.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationCreateDto.kt
@@ -1,0 +1,5 @@
+package dnd11th.blooming.api.dto.location
+
+data class LocationCreateDto(
+    val name: String,
+)

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationModifyRequest.kt
@@ -1,8 +1,6 @@
 package dnd11th.blooming.api.dto.location
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
 
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -12,11 +10,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 )
 data class LocationModifyRequest(
 	@field:Schema(description = "수정할 위치 이름", example = "거실")
-    @field:NotNull(message = "새로운 위치명은 필수값입니다.")
-    @field:NotBlank(message = "새로운 위치명은 비어있을 수 없습니다.")
-    @JsonProperty("name")
-    private val _name: String?,
-) {
-    val name: String
-        get() = _name!!
-}
+	@field:NotBlank(message = "새로운 위치명은 필수값입니다.")
+    val name: String?,
+)

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationModifyRequest.kt
@@ -1,5 +1,8 @@
 package dnd11th.blooming.api.dto.location
 
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(
@@ -7,6 +10,8 @@ import io.swagger.v3.oas.annotations.media.Schema
     description = "위치 수정 요청",
 )
 data class LocationModifyRequest(
-    @field:Schema(description = "수정할 위치 이름", example = "거실")
+	@field:Schema(description = "수정할 위치 이름", example = "거실")
+    @NotNull(message = "새로운 위치명은 필수값입니다.")
+    @NotBlank(message = "새로운 위치명은 비어있을 수 없습니다.")
     val name: String,
 )

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationModifyRequest.kt
@@ -1,5 +1,6 @@
 package dnd11th.blooming.api.dto.location
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 
@@ -13,5 +14,9 @@ data class LocationModifyRequest(
 	@field:Schema(description = "수정할 위치 이름", example = "거실")
     @field:NotNull(message = "새로운 위치명은 필수값입니다.")
     @field:NotBlank(message = "새로운 위치명은 비어있을 수 없습니다.")
-    val name: String,
-)
+    @JsonProperty("name")
+    private val _name: String?,
+) {
+    val name: String
+        get() = _name!!
+}

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationModifyRequest.kt
@@ -11,7 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 )
 data class LocationModifyRequest(
 	@field:Schema(description = "수정할 위치 이름", example = "거실")
-    @NotNull(message = "새로운 위치명은 필수값입니다.")
-    @NotBlank(message = "새로운 위치명은 비어있을 수 없습니다.")
+    @field:NotNull(message = "새로운 위치명은 필수값입니다.")
+    @field:NotBlank(message = "새로운 위치명은 비어있을 수 없습니다.")
     val name: String,
 )

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationModifyRequest.kt
@@ -1,15 +1,14 @@
 package dnd11th.blooming.api.dto.location
 
-import jakarta.validation.constraints.NotBlank
-
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
 
 @Schema(
     name = "Location Modify Request",
     description = "위치 수정 요청",
 )
 data class LocationModifyRequest(
-	@field:Schema(description = "수정할 위치 이름", example = "거실")
-	@field:NotBlank(message = "새로운 위치명은 필수값입니다.")
+    @field:Schema(description = "수정할 위치 이름", example = "거실")
+    @field:NotBlank(message = "새로운 위치명은 필수값입니다.")
     val name: String?,
 )

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationResponse.kt
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 )
 data class LocationResponse(
     @field:Schema(description = "위치 ID", example = "3")
-    val id: Long,
+    val id: Long?,
     @field:Schema(description = "위치 이름", example = "베란다")
     val name: String,
 ) {

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveRequest.kt
@@ -1,6 +1,5 @@
 package dnd11th.blooming.api.dto.location
 
-import dnd11th.blooming.domain.entity.Location
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 
@@ -13,8 +12,8 @@ data class LocationSaveRequest(
     @field:Schema(description = "새로운 위치 이름", example = "부엌")
     val name: String?,
 ) {
-    fun toLocation(): Location =
-        Location(
+    fun toLocationCreateDto(): LocationCreateDto =
+        LocationCreateDto(
             name = name!!,
         )
 }

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveRequest.kt
@@ -10,9 +10,8 @@ import io.swagger.v3.oas.annotations.media.Schema
     description = "위치 저장 요청",
 )
 data class LocationSaveRequest(
+    @field:NotBlank(message = "새로운 위치명은 필수값입니다.")
 	@field:Schema(description = "새로운 위치 이름", example = "부엌")
-    @field:NotNull(message = "새로운 위치명은 필수값입니다.")
-    @field:NotBlank(message = "새로운 위치명은 비어있을 수 없습니다.")
     val name: String?,
 ) {
     fun toLocation(): Location =

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveRequest.kt
@@ -13,10 +13,10 @@ data class LocationSaveRequest(
 	@field:Schema(description = "새로운 위치 이름", example = "부엌")
     @field:NotNull(message = "새로운 위치명은 필수값입니다.")
     @field:NotBlank(message = "새로운 위치명은 비어있을 수 없습니다.")
-    val name: String,
+    val name: String?,
 ) {
     fun toLocation(): Location =
         Location(
-            name = name,
+            name = name!!,
         )
 }

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveRequest.kt
@@ -1,6 +1,8 @@
 package dnd11th.blooming.api.dto.location
 
 import dnd11th.blooming.domain.entity.Location
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(
@@ -8,7 +10,9 @@ import io.swagger.v3.oas.annotations.media.Schema
     description = "위치 저장 요청",
 )
 data class LocationSaveRequest(
-    @field:Schema(description = "새로운 위치 이름", example = "부엌")
+	@field:Schema(description = "새로운 위치 이름", example = "부엌")
+    @NotNull(message = "새로운 위치명은 필수값입니다.")
+    @NotBlank(message = "새로운 위치명은 비어있을 수 없습니다.")
     val name: String,
 ) {
     fun toLocation(): Location =

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveRequest.kt
@@ -11,8 +11,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 )
 data class LocationSaveRequest(
 	@field:Schema(description = "새로운 위치 이름", example = "부엌")
-    @NotNull(message = "새로운 위치명은 필수값입니다.")
-    @NotBlank(message = "새로운 위치명은 비어있을 수 없습니다.")
+    @field:NotNull(message = "새로운 위치명은 필수값입니다.")
+    @field:NotBlank(message = "새로운 위치명은 비어있을 수 없습니다.")
     val name: String,
 ) {
     fun toLocation(): Location =

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveRequest.kt
@@ -1,9 +1,8 @@
 package dnd11th.blooming.api.dto.location
 
 import dnd11th.blooming.domain.entity.Location
-import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
 
 @Schema(
     name = "Location Save Request",
@@ -11,7 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 )
 data class LocationSaveRequest(
     @field:NotBlank(message = "새로운 위치명은 필수값입니다.")
-	@field:Schema(description = "새로운 위치 이름", example = "부엌")
+    @field:Schema(description = "새로운 위치 이름", example = "부엌")
     val name: String?,
 ) {
     fun toLocation(): Location =

--- a/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/location/LocationSaveResponse.kt
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 )
 class LocationSaveResponse(
     @field:Schema(description = "저장된 위치 ID", example = "4")
-    val id: Long,
+    val id: Long?,
     @field:Schema(description = "위치 이름", example = "부엌")
     val name: String,
 ) {

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/AlarmModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/AlarmModifyRequest.kt
@@ -9,29 +9,26 @@ import jakarta.validation.constraints.NotNull
     description = "알림 수정 요청",
 )
 data class AlarmModifyRequest(
+	@field:Schema(description = "물주기 알림 여부", example = "true")
     @field:NotNull(message = "물주기 알림 여부는 필수값입니다.")
-    @NotNull(message = "물주기 알림 여부는 필수값입니다.")
-    @field:Schema(description = "물주기 알림 여부", example = "true")
-    val waterAlarm: Boolean,
-    @field:Schema(description = "물주기 알림 주기", example = "4")
-    val waterPeriod: Int?,
-    @field:NotNull(message = "비료주기 알림 여부는 필수값입니다.")
-    @NotNull(message = "비료주기 알림 여부는 필수값입니다.")
-    @field:Schema(description = "비료주기 알림 여부", example = "false")
-    val fertilizerAlarm: Boolean,
-    @field:Schema(description = "비료주기 알림 주기", example = "45")
-    val fertilizerPeriod: Int?,
-    @field:NotNull(message = "건강확인 알림 여부는 필수값입니다.")
-    @NotNull(message = "건강확인 알림 여부는 필수값입니다.")
-    @field:Schema(description = "건강확인 알림 여부", example = "true")
-    val healthCheckAlarm: Boolean,
+    val waterAlarm: Boolean?,
+	@field:Schema(description = "물주기 알림 주기", example = "4")
+	val waterPeriod: Int?,
+	@field:Schema(description = "비료주기 알림 여부", example = "false")
+	@field:NotNull(message = "비료주기 알림 여부는 필수값입니다.")
+    val fertilizerAlarm: Boolean?,
+	@field:Schema(description = "비료주기 알림 주기", example = "45")
+	val fertilizerPeriod: Int?,
+	@field:Schema(description = "건강확인 알림 여부", example = "true")
+	@field:NotNull(message = "건강확인 알림 여부는 필수값입니다.")
+    val healthCheckAlarm: Boolean?,
 ) {
     fun toAlarm(): Alarm =
         Alarm(
-            waterAlarm = waterAlarm,
+            waterAlarm = waterAlarm!!,
             waterPeriod = waterPeriod,
-            fertilizerAlarm = fertilizerAlarm,
+            fertilizerAlarm = fertilizerAlarm!!,
             fertilizerPeriod = fertilizerPeriod,
-            healthCheckAlarm = healthCheckAlarm,
+            healthCheckAlarm = healthCheckAlarm!!,
         )
 }

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/AlarmModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/AlarmModifyRequest.kt
@@ -2,20 +2,24 @@ package dnd11th.blooming.api.dto.myplant
 
 import dnd11th.blooming.domain.entity.Alarm
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
 
 @Schema(
     name = "Alarm Modify Request",
     description = "알림 수정 요청",
 )
 data class AlarmModifyRequest(
+    @NotNull(message = "물주기 알림 여부는 필수값입니다.")
     @field:Schema(description = "물주기 알림 여부", example = "true")
     val waterAlarm: Boolean,
     @field:Schema(description = "물주기 알림 주기", example = "4")
     val waterPeriod: Int?,
+    @NotNull(message = "비료주기 알림 여부는 필수값입니다.")
     @field:Schema(description = "비료주기 알림 여부", example = "false")
     val fertilizerAlarm: Boolean,
     @field:Schema(description = "비료주기 알림 주기", example = "45")
     val fertilizerPeriod: Int?,
+    @NotNull(message = "건강확인 알림 여부는 필수값입니다.")
     @field:Schema(description = "건강확인 알림 여부", example = "true")
     val healthCheckAlarm: Boolean,
 ) {

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/AlarmModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/AlarmModifyRequest.kt
@@ -9,18 +9,18 @@ import jakarta.validation.constraints.NotNull
     description = "알림 수정 요청",
 )
 data class AlarmModifyRequest(
-	@field:Schema(description = "물주기 알림 여부", example = "true")
+    @field:Schema(description = "물주기 알림 여부", example = "true")
     @field:NotNull(message = "물주기 알림 여부는 필수값입니다.")
     val waterAlarm: Boolean?,
-	@field:Schema(description = "물주기 알림 주기", example = "4")
-	val waterPeriod: Int?,
-	@field:Schema(description = "비료주기 알림 여부", example = "false")
-	@field:NotNull(message = "비료주기 알림 여부는 필수값입니다.")
+    @field:Schema(description = "물주기 알림 주기", example = "4")
+    val waterPeriod: Int?,
+    @field:Schema(description = "비료주기 알림 여부", example = "false")
+    @field:NotNull(message = "비료주기 알림 여부는 필수값입니다.")
     val fertilizerAlarm: Boolean?,
-	@field:Schema(description = "비료주기 알림 주기", example = "45")
-	val fertilizerPeriod: Int?,
-	@field:Schema(description = "건강확인 알림 여부", example = "true")
-	@field:NotNull(message = "건강확인 알림 여부는 필수값입니다.")
+    @field:Schema(description = "비료주기 알림 주기", example = "45")
+    val fertilizerPeriod: Int?,
+    @field:Schema(description = "건강확인 알림 여부", example = "true")
+    @field:NotNull(message = "건강확인 알림 여부는 필수값입니다.")
     val healthCheckAlarm: Boolean?,
 ) {
     fun toAlarm(): Alarm =

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/AlarmModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/AlarmModifyRequest.kt
@@ -9,16 +9,19 @@ import jakarta.validation.constraints.NotNull
     description = "알림 수정 요청",
 )
 data class AlarmModifyRequest(
+    @field:NotNull(message = "물주기 알림 여부는 필수값입니다.")
     @NotNull(message = "물주기 알림 여부는 필수값입니다.")
     @field:Schema(description = "물주기 알림 여부", example = "true")
     val waterAlarm: Boolean,
     @field:Schema(description = "물주기 알림 주기", example = "4")
     val waterPeriod: Int?,
+    @field:NotNull(message = "비료주기 알림 여부는 필수값입니다.")
     @NotNull(message = "비료주기 알림 여부는 필수값입니다.")
     @field:Schema(description = "비료주기 알림 여부", example = "false")
     val fertilizerAlarm: Boolean,
     @field:Schema(description = "비료주기 알림 주기", example = "45")
     val fertilizerPeriod: Int?,
+    @field:NotNull(message = "건강확인 알림 여부는 필수값입니다.")
     @NotNull(message = "건강확인 알림 여부는 필수값입니다.")
     @field:Schema(description = "건강확인 알림 여부", example = "true")
     val healthCheckAlarm: Boolean,

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantCreateDto.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantCreateDto.kt
@@ -1,0 +1,15 @@
+package dnd11th.blooming.api.dto.myplant
+
+import java.time.LocalDate
+
+data class MyPlantCreateDto(
+    val nickname: String,
+    val startDate: LocalDate,
+    val lastWateredDate: LocalDate,
+    val lastFertilizerDate: LocalDate,
+    val waterAlarm: Boolean,
+    val waterPeriod: Int?,
+    val fertilizerAlarm: Boolean,
+    val fertilizerPeriod: Int?,
+    val healthCheckAlarm: Boolean,
+)

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantHealthCheckRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantHealthCheckRequest.kt
@@ -1,5 +1,7 @@
 package dnd11th.blooming.api.dto.myplant
 
+import jakarta.validation.constraints.NotNull
+
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(
@@ -7,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema
     description = "건강확인 알림 변경 요청",
 )
 data class MyPlantHealthCheckRequest(
+    @NotNull(message = "건강확인 알림 여부는 필수값입니다.")
     @field:Schema(description = "건강확인 알림 여부", example = "true")
     val healthCheck: Boolean,
 )

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantHealthCheckRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantHealthCheckRequest.kt
@@ -1,5 +1,6 @@
 package dnd11th.blooming.api.dto.myplant
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotNull
 
 import io.swagger.v3.oas.annotations.media.Schema
@@ -11,5 +12,9 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class MyPlantHealthCheckRequest(
     @field:Schema(description = "건강확인 알림 여부", example = "true")
     @field:NotNull(message = "건강확인 알림 여부는 필수값입니다.")
-    val healthCheck: Boolean,
-)
+    @JsonProperty("healthCheck")
+    private val _healthCheck: Boolean?,
+) {
+    val healthCheck: Boolean
+        get() = _healthCheck!!
+}

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantHealthCheckRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantHealthCheckRequest.kt
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema
     description = "건강확인 알림 변경 요청",
 )
 data class MyPlantHealthCheckRequest(
-    @NotNull(message = "건강확인 알림 여부는 필수값입니다.")
     @field:Schema(description = "건강확인 알림 여부", example = "true")
+    @field:NotNull(message = "건강확인 알림 여부는 필수값입니다.")
     val healthCheck: Boolean,
 )

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantHealthCheckRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantHealthCheckRequest.kt
@@ -1,6 +1,5 @@
 package dnd11th.blooming.api.dto.myplant
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotNull
 
 import io.swagger.v3.oas.annotations.media.Schema
@@ -12,9 +11,5 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class MyPlantHealthCheckRequest(
     @field:Schema(description = "건강확인 알림 여부", example = "true")
     @field:NotNull(message = "건강확인 알림 여부는 필수값입니다.")
-    @JsonProperty("healthCheck")
-    private val _healthCheck: Boolean?,
-) {
-    val healthCheck: Boolean
-        get() = _healthCheck!!
-}
+    val healthCheck: Boolean?,
+)

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantHealthCheckRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantHealthCheckRequest.kt
@@ -1,8 +1,7 @@
 package dnd11th.blooming.api.dto.myplant
 
-import jakarta.validation.constraints.NotNull
-
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
 
 @Schema(
     name = "HealthCheck Alarm Modify Request",

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantIdWithImageUrl.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantIdWithImageUrl.kt
@@ -1,0 +1,6 @@
+package dnd11th.blooming.api.dto.myplant
+
+data class MyPlantIdWithImageUrl(
+    val imageUrl: String,
+    val myPlantId: Long,
+)

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantModifyRequest.kt
@@ -1,7 +1,7 @@
 package dnd11th.blooming.api.dto.myplant
 
-import jakarta.validation.constraints.PastOrPresent
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.PastOrPresent
 import java.time.LocalDate
 
 @Schema(

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantModifyRequest.kt
@@ -1,5 +1,7 @@
 package dnd11th.blooming.api.dto.myplant
 
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.PastOrPresent
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
@@ -9,13 +11,17 @@ import java.time.LocalDate
 )
 data class MyPlantModifyRequest(
     @field:Schema(description = "변경할 식물 별명", example = "쫑쫑이")
+    @field:NotBlank(message = "식물 별명은 비어있을 수 없습니다.")
     val nickname: String?,
     @field:Schema(description = "변경할 위치 ID", example = "4")
     val locationId: Long?,
     @field:Schema(description = "변경할 키우기 시작한 날짜", example = "2024-05-17")
+    @field:PastOrPresent(message = "키우기 시작한 날짜는 미래일 수 없습니다.")
     val startDate: LocalDate?,
     @field:Schema(description = "변경할 마지막으로 물 준 날짜", example = "2024-05-17")
+    @field:PastOrPresent(message = "마지막으로 물 준 날짜는 미래일 수 없습니다.")
     val lastWateredDate: LocalDate?,
     @field:Schema(description = "변경할 마지막으로 비료 준 날짜", example = "2024-05-17")
+    @field:PastOrPresent(message = "마지막으로 비료 준 날짜는 미래일 수 없습니다.")
     val lastFertilizerDate: LocalDate?,
 )

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantModifyRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantModifyRequest.kt
@@ -1,6 +1,5 @@
 package dnd11th.blooming.api.dto.myplant
 
-import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.PastOrPresent
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
@@ -11,7 +10,6 @@ import java.time.LocalDate
 )
 data class MyPlantModifyRequest(
     @field:Schema(description = "변경할 식물 별명", example = "쫑쫑이")
-    @field:NotBlank(message = "식물 별명은 비어있을 수 없습니다.")
     val nickname: String?,
     @field:Schema(description = "변경할 위치 ID", example = "4")
     val locationId: Long?,

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantResponse.kt
@@ -13,6 +13,7 @@ data class MyPlantResponse(
     val myPlantId: Long?,
     @field:Schema(description = "내 식물 별명", example = "쫑쫑이")
     val nickname: String,
+    @field:Schema(description = "이미지 URL", example = "image.com/7")
     val imageUrl: String,
     @field:Schema(description = "내 식물 학명", example = "몬스테라 델리오사")
     val scientificName: String,

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantResponse.kt
@@ -13,6 +13,7 @@ data class MyPlantResponse(
     val myPlantId: Long?,
     @field:Schema(description = "내 식물 별명", example = "쫑쫑이")
     val nickname: String,
+    val imageUrl: String,
     @field:Schema(description = "내 식물 학명", example = "몬스테라 델리오사")
     val scientificName: String,
     @field:Schema(description = "다음 물주기까지 남은 날짜", example = "4")
@@ -23,11 +24,13 @@ data class MyPlantResponse(
     companion object {
         fun of(
             myPlant: MyPlant,
+            imageUrl: String,
             now: LocalDate,
         ): MyPlantResponse =
             MyPlantResponse(
                 myPlantId = myPlant.id,
                 nickname = myPlant.nickname,
+                imageUrl = imageUrl,
                 scientificName = myPlant.scientificName,
                 waterRemainDay = myPlant.getWaterRemainDay(now),
                 fertilizerRemainDay = myPlant.getFerilizerRemainDate(now),

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantResponse.kt
@@ -10,7 +10,7 @@ import java.time.LocalDate
 )
 data class MyPlantResponse(
     @field:Schema(description = "내 식물 ID", example = "17")
-    val myPlantId: Long,
+    val myPlantId: Long?,
     @field:Schema(description = "내 식물 별명", example = "쫑쫑이")
     val nickname: String,
     @field:Schema(description = "내 식물 학명", example = "몬스테라 델리오사")

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
@@ -15,15 +15,16 @@ import java.time.LocalDate
 )
 data class MyPlantSaveRequest(
     // TODO : 식물 종류를 String이 아니라 plantId로 받기
-	@field:Schema(description = "식물 ID", example = "3")
-    @field:NotBlank(message = "식물 종류는 필수값입니다.")
+    @field:Schema(description = "식물 ID", example = "3")
+    @field:NotNull(message = "식물 종류는 필수값입니다.")
     val plantId: Long?,
+    @field:Schema(description = "식물 별명", example = "쫑쫑이")
     @field:NotBlank(message = "식물 별명은 필수값입니다.")
     val nickname: String?,
     @field:Schema(description = "위치 ID", example = "4")
     @field:NotNull(message = "위치는 필수값입니다.")
     val locationId: Long?,
-	// TODO : 키우기 시작한 날짜, 마지막으로 물 준 날짜, 마지막으로 비료 준 날짜 optional로 만들기
+    // TODO : 키우기 시작한 날짜, 마지막으로 물 준 날짜, 마지막으로 비료 준 날짜 optional로 만들기
     @field:Schema(description = "키우기 시작한 날짜", example = "2024-05-17")
     @field:PastOrPresent(message = "키우기 시작한 날짜는 미래일 수 없습니다.")
     val startDate: LocalDate,
@@ -48,8 +49,8 @@ data class MyPlantSaveRequest(
     val healthCheckAlarm: Boolean?,
 ) {
     fun toMyPlant(
-	    location: Location,
-	    scientificName: String,
+        location: Location,
+        scientificName: String,
         now: LocalDate,
     ): MyPlant =
         MyPlant(

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
@@ -4,6 +4,9 @@ import dnd11th.blooming.domain.entity.Alarm
 import dnd11th.blooming.domain.entity.Location
 import dnd11th.blooming.domain.entity.MyPlant
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.PastOrPresent
 import java.time.LocalDate
 
 @Schema(
@@ -17,15 +20,20 @@ data class MyPlantSaveRequest(
     @field:NotBlank(message = "식물 종류는 비어있을 수 없습니다.")
     val scientificName: String,
     @field:Schema(description = "내 식물 별명", example = "쫑쫑이")
+    @field:NotBlank(message = "식물 별명은 비어있을 수 없습니다.")
     val nickname: String,
     @field:Schema(description = "위치 ID", example = "4")
     @field:NotNull(message = "위치는 필수값입니다.")
     val locationId: Long,
+	// TODO : 키우기 시작한 날짜, 마지막으로 물 준 날짜, 마지막으로 비료 준 날짜 optional로 만들기
     @field:Schema(description = "키우기 시작한 날짜", example = "2024-05-17")
+    @field:PastOrPresent(message = "키우기 시작한 날짜는 미래일 수 없습니다.")
     val startDate: LocalDate,
     @field:Schema(description = "마지막으로 물 준 날짜", example = "2024-05-17")
+    @field:PastOrPresent(message = "마지막으로 물 준 날짜는 미래일 수 없습니다.")
     val lastWateredDate: LocalDate,
     @field:Schema(description = "마지막으로 비료 준 날짜", example = "2024-05-17")
+    @field:PastOrPresent(message = "마지막으로 비료 준 날짜는 미래일 수 없습니다.")
     val lastFertilizerDate: LocalDate,
     @field:NotNull(message = "물주기 알림 여부는 필수값입니다.")
     @field:Schema(description = "물주기 알림 여부", example = "true")

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
@@ -18,8 +18,7 @@ data class MyPlantSaveRequest(
 	@field:Schema(description = "식물 ID", example = "3")
     @field:NotNull(message = "식물 종류는 필수값입니다.")
     @field:NotBlank(message = "식물 종류는 비어있을 수 없습니다.")
-    val scientificName: String,
-    @field:Schema(description = "내 식물 별명", example = "쫑쫑이")
+    val plantId: Long,
     @field:NotBlank(message = "식물 별명은 비어있을 수 없습니다.")
     val nickname: String,
     @field:Schema(description = "위치 ID", example = "4")
@@ -50,7 +49,8 @@ data class MyPlantSaveRequest(
     val healthCheckAlarm: Boolean,
 ) {
     fun toMyPlant(
-        location: Location,
+	    location: Location,
+	    scientificName: String,
         now: LocalDate,
     ): MyPlant =
         MyPlant(

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
@@ -11,11 +11,15 @@ import java.time.LocalDate
     description = "내 식물 저장 요청",
 )
 data class MyPlantSaveRequest(
-    @field:Schema(description = "식물 ID", example = "3")
+    // TODO : 식물 종류를 String이 아니라 plantId로 받기
+	@field:Schema(description = "식물 ID", example = "3")
+    @field:NotNull(message = "식물 종류는 필수값입니다.")
+    @field:NotBlank(message = "식물 종류는 비어있을 수 없습니다.")
     val scientificName: String,
     @field:Schema(description = "내 식물 별명", example = "쫑쫑이")
     val nickname: String,
     @field:Schema(description = "위치 ID", example = "4")
+    @field:NotNull(message = "위치는 필수값입니다.")
     val locationId: Long,
     @field:Schema(description = "키우기 시작한 날짜", example = "2024-05-17")
     val startDate: LocalDate,
@@ -23,14 +27,17 @@ data class MyPlantSaveRequest(
     val lastWateredDate: LocalDate,
     @field:Schema(description = "마지막으로 비료 준 날짜", example = "2024-05-17")
     val lastFertilizerDate: LocalDate,
+    @field:NotNull(message = "물주기 알림 여부는 필수값입니다.")
     @field:Schema(description = "물주기 알림 여부", example = "true")
     val waterAlarm: Boolean,
     @field:Schema(description = "물주기 알림 주기", example = "15")
     val waterPeriod: Int?,
+    @field:NotNull(message = "비료주기 알림 여부는 필수값입니다.")
     @field:Schema(description = "비료주기 알림 여부", example = "false")
     val fertilizerAlarm: Boolean,
     @field:Schema(description = "비료주기 알림 주기", example = "45")
     val fertilizerPeriod: Int?,
+    @field:NotNull(message = "건강확인 알림 여부는 필수값입니다.")
     @field:Schema(description = "건강확인 알림 여부", example = "true")
     val healthCheckAlarm: Boolean,
 ) {

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
@@ -1,8 +1,5 @@
 package dnd11th.blooming.api.dto.myplant
 
-import dnd11th.blooming.domain.entity.Alarm
-import dnd11th.blooming.domain.entity.Location
-import dnd11th.blooming.domain.entity.MyPlant
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
@@ -48,29 +45,16 @@ data class MyPlantSaveRequest(
     @field:Schema(description = "건강확인 알림 여부", example = "true")
     val healthCheckAlarm: Boolean?,
 ) {
-    fun toMyPlant(
-        location: Location,
-        scientificName: String,
-        now: LocalDate,
-    ): MyPlant =
-        MyPlant(
-            scientificName = scientificName,
+    fun toMyPlantCreateDto(): MyPlantCreateDto =
+        MyPlantCreateDto(
             nickname = nickname!!,
             startDate = startDate,
             lastWateredDate = lastWateredDate,
             lastFertilizerDate = lastFertilizerDate,
-            currentDate = now,
-            alarm =
-                Alarm(
-                    waterAlarm = waterAlarm!!,
-                    waterPeriod = waterPeriod,
-                    fertilizerAlarm = fertilizerAlarm!!,
-                    fertilizerPeriod = fertilizerPeriod,
-                    healthCheckAlarm = healthCheckAlarm!!,
-                ),
-        ).also {
-            it.setLocationRelation(location)
-            // TODO : 유저와 매핑 필요
-            // TODO : 식물가이드와 매핑 필요
-        }
+            waterAlarm = waterAlarm!!,
+            waterPeriod = waterPeriod,
+            fertilizerAlarm = fertilizerAlarm!!,
+            fertilizerPeriod = fertilizerPeriod,
+            healthCheckAlarm = healthCheckAlarm!!,
+        )
 }

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
@@ -16,15 +16,13 @@ import java.time.LocalDate
 data class MyPlantSaveRequest(
     // TODO : 식물 종류를 String이 아니라 plantId로 받기
 	@field:Schema(description = "식물 ID", example = "3")
-    @field:NotNull(message = "식물 종류는 필수값입니다.")
-    @field:NotBlank(message = "식물 종류는 비어있을 수 없습니다.")
-    val plantId: Long,
-    @field:NotNull(message = "식물 별명은 필수값입니다.")
-    @field:NotBlank(message = "식물 별명은 비어있을 수 없습니다.")
-    val nickname: String,
+    @field:NotBlank(message = "식물 종류는 필수값입니다.")
+    val plantId: Long?,
+    @field:NotBlank(message = "식물 별명은 필수값입니다.")
+    val nickname: String?,
     @field:Schema(description = "위치 ID", example = "4")
     @field:NotNull(message = "위치는 필수값입니다.")
-    val locationId: Long,
+    val locationId: Long?,
 	// TODO : 키우기 시작한 날짜, 마지막으로 물 준 날짜, 마지막으로 비료 준 날짜 optional로 만들기
     @field:Schema(description = "키우기 시작한 날짜", example = "2024-05-17")
     @field:PastOrPresent(message = "키우기 시작한 날짜는 미래일 수 없습니다.")
@@ -37,17 +35,17 @@ data class MyPlantSaveRequest(
     val lastFertilizerDate: LocalDate,
     @field:NotNull(message = "물주기 알림 여부는 필수값입니다.")
     @field:Schema(description = "물주기 알림 여부", example = "true")
-    val waterAlarm: Boolean,
+    val waterAlarm: Boolean?,
     @field:Schema(description = "물주기 알림 주기", example = "15")
     val waterPeriod: Int?,
     @field:NotNull(message = "비료주기 알림 여부는 필수값입니다.")
     @field:Schema(description = "비료주기 알림 여부", example = "false")
-    val fertilizerAlarm: Boolean,
+    val fertilizerAlarm: Boolean?,
     @field:Schema(description = "비료주기 알림 주기", example = "45")
     val fertilizerPeriod: Int?,
     @field:NotNull(message = "건강확인 알림 여부는 필수값입니다.")
     @field:Schema(description = "건강확인 알림 여부", example = "true")
-    val healthCheckAlarm: Boolean,
+    val healthCheckAlarm: Boolean?,
 ) {
     fun toMyPlant(
 	    location: Location,
@@ -56,18 +54,18 @@ data class MyPlantSaveRequest(
     ): MyPlant =
         MyPlant(
             scientificName = scientificName,
-            nickname = nickname,
+            nickname = nickname!!,
             startDate = startDate,
             lastWateredDate = lastWateredDate,
             lastFertilizerDate = lastFertilizerDate,
             currentDate = now,
             alarm =
                 Alarm(
-                    waterAlarm = waterAlarm,
+                    waterAlarm = waterAlarm!!,
                     waterPeriod = waterPeriod,
-                    fertilizerAlarm = fertilizerAlarm,
+                    fertilizerAlarm = fertilizerAlarm!!,
                     fertilizerPeriod = fertilizerPeriod,
-                    healthCheckAlarm = healthCheckAlarm,
+                    healthCheckAlarm = healthCheckAlarm!!,
                 ),
         ).also {
             it.setLocationRelation(location)

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveRequest.kt
@@ -19,6 +19,7 @@ data class MyPlantSaveRequest(
     @field:NotNull(message = "식물 종류는 필수값입니다.")
     @field:NotBlank(message = "식물 종류는 비어있을 수 없습니다.")
     val plantId: Long,
+    @field:NotNull(message = "식물 별명은 필수값입니다.")
     @field:NotBlank(message = "식물 별명은 비어있을 수 없습니다.")
     val nickname: String,
     @field:Schema(description = "위치 ID", example = "4")

--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantSaveResponse.kt
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 )
 data class MyPlantSaveResponse(
     @field:Schema(description = "내 식물 ID", example = "17")
-    val myPlantId: Long,
+    val myPlantId: Long?,
 ) {
     @field:Schema(description = "저장메시지", example = "등록 되었습니다.")
     val message: String = "등록 되었습니다."

--- a/src/main/kotlin/dnd11th/blooming/api/dto/user/IdTokenRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/user/IdTokenRequest.kt
@@ -3,6 +3,6 @@ package dnd11th.blooming.api.dto.user
 import jakarta.validation.constraints.NotNull
 
 data class IdTokenRequest(
-    @NotNull(message = "idToken은 필수값입니다.")
+    @field:NotNull(message = "idToken은 필수값입니다.")
     val idToken: String,
 )

--- a/src/main/kotlin/dnd11th/blooming/api/dto/user/IdTokenRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/user/IdTokenRequest.kt
@@ -1,8 +1,8 @@
 package dnd11th.blooming.api.dto.user
 
-import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.NotBlank
 
 data class IdTokenRequest(
-    @field:NotNull(message = "idToken은 필수값입니다.")
+    @field:NotBlank(message = "idToken은 필수값입니다.")
     val idToken: String,
 )

--- a/src/main/kotlin/dnd11th/blooming/api/dto/user/IdTokenRequest.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/user/IdTokenRequest.kt
@@ -1,5 +1,8 @@
 package dnd11th.blooming.api.dto.user
 
+import jakarta.validation.constraints.NotNull
+
 data class IdTokenRequest(
+    @NotNull(message = "idToken은 필수값입니다.")
     val idToken: String,
 )

--- a/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
@@ -4,6 +4,7 @@ import dnd11th.blooming.api.dto.image.ImageFavoriteModifyRequest
 import dnd11th.blooming.api.dto.image.ImageSaveRequest
 import dnd11th.blooming.common.exception.ErrorType
 import dnd11th.blooming.common.exception.NotFoundException
+import dnd11th.blooming.domain.entity.Image
 import dnd11th.blooming.domain.repository.ImageRepository
 import dnd11th.blooming.domain.repository.MyPlantRepository
 import org.springframework.data.repository.findByIdOrNull
@@ -26,7 +27,12 @@ class ImageService(
             myPlantRepository.findByIdOrNull(myPlantId)
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
 
-        val image = request.toImage(myPlant, now)
+        val image =
+            Image.createImage(
+                dto = request.toImageCreateDto(),
+                myPlant = myPlant,
+                now = now,
+            )
 
         imageRepository.save(image)
     }

--- a/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
@@ -10,7 +10,6 @@ import dnd11th.blooming.domain.repository.MyPlantRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 
 @Service
 class ImageService(
@@ -21,13 +20,12 @@ class ImageService(
     fun saveImage(
         myPlantId: Long,
         dto: ImageCreateDto,
-        now: LocalDate,
     ) {
         val myPlant =
             myPlantRepository.findByIdOrNull(myPlantId)
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
 
-        val image = Image.createImage(dto, myPlant, now)
+        val image = Image.createImage(dto, myPlant)
 
         imageRepository.save(image)
     }

--- a/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
@@ -1,7 +1,7 @@
 package dnd11th.blooming.api.service.image
 
+import dnd11th.blooming.api.dto.image.ImageCreateDto
 import dnd11th.blooming.api.dto.image.ImageFavoriteModifyRequest
-import dnd11th.blooming.api.dto.image.ImageSaveRequest
 import dnd11th.blooming.common.exception.ErrorType
 import dnd11th.blooming.common.exception.NotFoundException
 import dnd11th.blooming.domain.entity.Image
@@ -20,19 +20,14 @@ class ImageService(
     @Transactional
     fun saveImage(
         myPlantId: Long,
-        request: ImageSaveRequest,
+        dto: ImageCreateDto,
         now: LocalDate,
     ) {
         val myPlant =
             myPlantRepository.findByIdOrNull(myPlantId)
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
 
-        val image =
-            Image.createImage(
-                dto = request.toImageCreateDto(),
-                myPlant = myPlant,
-                now = now,
-            )
+        val image = Image.createImage(dto, myPlant, now)
 
         imageRepository.save(image)
     }

--- a/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
@@ -40,7 +40,7 @@ class ImageService(
             imageRepository.findByIdOrNull(imageId)
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_IMAGE)
 
-        image.modifyFavorite(request.favorite)
+        image.modifyFavorite(request.favorite!!)
     }
 
     @Transactional

--- a/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
@@ -1,7 +1,6 @@
 package dnd11th.blooming.api.service.image
 
 import dnd11th.blooming.api.dto.image.ImageCreateDto
-import dnd11th.blooming.api.dto.image.ImageFavoriteModifyRequest
 import dnd11th.blooming.common.exception.ErrorType
 import dnd11th.blooming.common.exception.NotFoundException
 import dnd11th.blooming.domain.entity.Image
@@ -33,13 +32,13 @@ class ImageService(
     @Transactional
     fun modifyFavorite(
         imageId: Long,
-        request: ImageFavoriteModifyRequest,
+        favorite: Boolean,
     ) {
         val image =
             imageRepository.findByIdOrNull(imageId)
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_IMAGE)
 
-        image.modifyFavorite(request.favorite!!)
+        image.modifyFavorite(favorite)
     }
 
     @Transactional

--- a/src/main/kotlin/dnd11th/blooming/api/service/location/LocationService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/location/LocationService.kt
@@ -37,7 +37,7 @@ class LocationService(
             locationRepository.findByIdOrNull(locationId)
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_LOCATION)
 
-        location.modifyName(request.name)
+        location.modifyName(request.name!!)
 
         return LocationResponse.from(location)
     }

--- a/src/main/kotlin/dnd11th/blooming/api/service/location/LocationService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/location/LocationService.kt
@@ -11,20 +11,16 @@ import dnd11th.blooming.domain.repository.LocationRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 
 @Service
 class LocationService(
     private val locationRepository: LocationRepository,
 ) {
     @Transactional
-    fun saveLocation(
-        dto: LocationCreateDto,
-        now: LocalDate,
-    ): LocationSaveResponse {
+    fun saveLocation(dto: LocationCreateDto): LocationSaveResponse {
         // TODO : 유저와 매핑 필요
 
-        val location = Location.createLocation(dto, now)
+        val location = Location.createLocation(dto)
 
         return LocationSaveResponse.from(locationRepository.save(location))
     }

--- a/src/main/kotlin/dnd11th/blooming/api/service/location/LocationService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/location/LocationService.kt
@@ -6,19 +6,30 @@ import dnd11th.blooming.api.dto.location.LocationSaveRequest
 import dnd11th.blooming.api.dto.location.LocationSaveResponse
 import dnd11th.blooming.common.exception.ErrorType
 import dnd11th.blooming.common.exception.NotFoundException
+import dnd11th.blooming.domain.entity.Location
 import dnd11th.blooming.domain.repository.LocationRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 
 @Service
 class LocationService(
     private val locationRepository: LocationRepository,
 ) {
     @Transactional
-    fun saveLocation(request: LocationSaveRequest): LocationSaveResponse {
+    fun saveLocation(
+        request: LocationSaveRequest,
+        now: LocalDate,
+    ): LocationSaveResponse {
         // TODO : 유저와 매핑 필요
-        val location = request.toLocation()
+
+        val location =
+            Location.createLocation(
+                request.toLocationCreateDto(),
+                now,
+            )
+
         return LocationSaveResponse.from(locationRepository.save(location))
     }
 

--- a/src/main/kotlin/dnd11th/blooming/api/service/location/LocationService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/location/LocationService.kt
@@ -1,8 +1,8 @@
 package dnd11th.blooming.api.service.location
 
+import dnd11th.blooming.api.dto.location.LocationCreateDto
 import dnd11th.blooming.api.dto.location.LocationModifyRequest
 import dnd11th.blooming.api.dto.location.LocationResponse
-import dnd11th.blooming.api.dto.location.LocationSaveRequest
 import dnd11th.blooming.api.dto.location.LocationSaveResponse
 import dnd11th.blooming.common.exception.ErrorType
 import dnd11th.blooming.common.exception.NotFoundException
@@ -19,16 +19,12 @@ class LocationService(
 ) {
     @Transactional
     fun saveLocation(
-        request: LocationSaveRequest,
+        dto: LocationCreateDto,
         now: LocalDate,
     ): LocationSaveResponse {
         // TODO : 유저와 매핑 필요
 
-        val location =
-            Location.createLocation(
-                request.toLocationCreateDto(),
-                now,
-            )
+        val location = Location.createLocation(dto, now)
 
         return LocationSaveResponse.from(locationRepository.save(location))
     }

--- a/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
@@ -30,7 +30,6 @@ class MyPlantService(
     fun saveMyPlant(
         dto: MyPlantCreateDto,
         locationId: Long,
-        now: LocalDate,
     ): MyPlantSaveResponse {
         val location =
             locationRepository
@@ -41,7 +40,7 @@ class MyPlantService(
         val plant = "몬스테라 델리오사"
 
         val myPlant =
-            MyPlant.createMyPlant(dto, location, plant, now)
+            MyPlant.createMyPlant(dto, location, plant)
 
         val savedPlant = myPlantRepository.save(myPlant)
 

--- a/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
@@ -9,7 +9,6 @@ import dnd11th.blooming.api.dto.myplant.MyPlantResponse
 import dnd11th.blooming.api.dto.myplant.MyPlantSaveRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantSaveResponse
 import dnd11th.blooming.common.exception.ErrorType
-import dnd11th.blooming.common.exception.InvalidDateException
 import dnd11th.blooming.common.exception.NotFoundException
 import dnd11th.blooming.domain.entity.MyPlant
 import dnd11th.blooming.domain.repository.ImageRepository
@@ -28,14 +27,7 @@ class MyPlantService(
     private val imageRepository: ImageRepository,
 ) {
     @Transactional
-    fun saveMyPlant(
-        request: MyPlantSaveRequest,
-        now: LocalDate,
-    ): MyPlantSaveResponse {
-        validateDateNotInFuture(request.startDate, now)
-        validateDateNotInFuture(request.lastWateredDate, now)
-        validateDateNotInFuture(request.lastFertilizerDate, now)
-
+    fun saveMyPlant(request: MyPlantSaveRequest): MyPlantSaveResponse {
         val location =
             locationRepository
                 .findByIdOrNull(request.locationId)
@@ -153,15 +145,6 @@ class MyPlantService(
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
 
         myPlant.modifyHealthCheck(request.healthCheck)
-    }
-
-    private fun validateDateNotInFuture(
-        targetDate: LocalDate,
-        currentDate: LocalDate,
-    ) {
-        if (targetDate.isAfter(currentDate)) {
-            throw InvalidDateException(ErrorType.INVALID_DATE)
-        }
     }
 
     private fun findSortedMyPlants(

--- a/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
@@ -37,9 +37,15 @@ class MyPlantService(
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_LOCATION)
 
         // TODO : 식물 가이드 데이터 가져오기 필요
-        val scientificName = "몬스테라 델리오사"
+        val plant = "몬스테라 델리오사"
 
-        val myPlant = request.toMyPlant(location, scientificName, now)
+        val myPlant =
+            MyPlant.createMyPlant(
+                dto = request.toMyPlantCreateDto(),
+                location = location,
+                plant = plant,
+                now = now,
+            )
 
         val savedPlant = myPlantRepository.save(myPlant)
 

--- a/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
@@ -154,7 +154,7 @@ class MyPlantService(
             myPlantRepository.findByIdOrNull(myPlantId)
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
 
-        myPlant.modifyHealthCheck(request.healthCheck)
+        myPlant.modifyHealthCheck(request.healthCheck!!)
     }
 
     private fun findSortedMyPlantsWithImage(

--- a/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
@@ -39,7 +39,7 @@ class MyPlantService(
         // TODO : 식물 가이드 데이터 가져오기 필요
         val scientificName = "몬스테라 델리오사"
 
-        val myPlant = request.toMyPlant(location, now, scientificName)
+        val myPlant = request.toMyPlant(location, scientificName, now)
 
         val savedPlant = myPlantRepository.save(myPlant)
 

--- a/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
@@ -27,13 +27,19 @@ class MyPlantService(
     private val imageRepository: ImageRepository,
 ) {
     @Transactional
-    fun saveMyPlant(request: MyPlantSaveRequest): MyPlantSaveResponse {
+    fun saveMyPlant(
+        request: MyPlantSaveRequest,
+        now: LocalDate,
+    ): MyPlantSaveResponse {
         val location =
             locationRepository
                 .findByIdOrNull(request.locationId)
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_LOCATION)
 
-        val myPlant = request.toMyPlant(location, now)
+        // TODO : 식물 가이드 데이터 가져오기 필요
+        val scientificName = "몬스테라 델리오사"
+
+        val myPlant = request.toMyPlant(location, now, scientificName)
 
         val savedPlant = myPlantRepository.save(myPlant)
 

--- a/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/myplant/MyPlantService.kt
@@ -1,12 +1,12 @@
 package dnd11th.blooming.api.service.myplant
 
 import dnd11th.blooming.api.dto.myplant.AlarmModifyRequest
+import dnd11th.blooming.api.dto.myplant.MyPlantCreateDto
 import dnd11th.blooming.api.dto.myplant.MyPlantDetailResponse
 import dnd11th.blooming.api.dto.myplant.MyPlantHealthCheckRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantModifyRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantQueryCreteria
 import dnd11th.blooming.api.dto.myplant.MyPlantResponse
-import dnd11th.blooming.api.dto.myplant.MyPlantSaveRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantSaveResponse
 import dnd11th.blooming.common.exception.ErrorType
 import dnd11th.blooming.common.exception.NotFoundException
@@ -28,24 +28,20 @@ class MyPlantService(
 ) {
     @Transactional
     fun saveMyPlant(
-        request: MyPlantSaveRequest,
+        dto: MyPlantCreateDto,
+        locationId: Long,
         now: LocalDate,
     ): MyPlantSaveResponse {
         val location =
             locationRepository
-                .findByIdOrNull(request.locationId)
+                .findByIdOrNull(locationId)
                 ?: throw NotFoundException(ErrorType.NOT_FOUND_LOCATION)
 
         // TODO : 식물 가이드 데이터 가져오기 필요
         val plant = "몬스테라 델리오사"
 
         val myPlant =
-            MyPlant.createMyPlant(
-                dto = request.toMyPlantCreateDto(),
-                location = location,
-                plant = plant,
-                now = now,
-            )
+            MyPlant.createMyPlant(dto, location, plant, now)
 
         val savedPlant = myPlantRepository.save(myPlant)
 

--- a/src/main/kotlin/dnd11th/blooming/common/exception/ErrorResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/exception/ErrorResponse.kt
@@ -6,12 +6,12 @@ import com.fasterxml.jackson.annotation.JsonInclude
 data class ErrorResponse private constructor(
     val code: ErrorType,
     val message: String,
-    val fields: Map<String, String>?,
+    val fields: List<FieldErrorResponse>?,
 ) {
     companion object {
         fun from(
             errorType: ErrorType,
-            fields: Map<String, String>? = null,
+            fields: List<FieldErrorResponse>? = null,
         ): ErrorResponse =
             ErrorResponse(
                 code = errorType,

--- a/src/main/kotlin/dnd11th/blooming/common/exception/ErrorResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/exception/ErrorResponse.kt
@@ -6,17 +6,17 @@ import com.fasterxml.jackson.annotation.JsonInclude
 data class ErrorResponse private constructor(
     val code: ErrorType,
     val message: String,
-    val field: List<String>?,
+    val fields: Map<String, String>?,
 ) {
     companion object {
         fun from(
             errorType: ErrorType,
-            field: List<String>? = null,
+            fields: Map<String, String>? = null,
         ): ErrorResponse =
             ErrorResponse(
                 code = errorType,
                 message = errorType.message,
-                field = field,
+                fields = fields,
             )
     }
 }

--- a/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
@@ -6,7 +6,6 @@ import org.springframework.http.HttpStatus
 enum class ErrorType(val status: HttpStatus, var message: String, val logLevel: LogLevel) {
     // COMMON
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error has occurred.", LogLevel.ERROR),
-    INVALID_DATE(HttpStatus.BAD_REQUEST, "올바르지 않은 날짜입니다.", LogLevel.DEBUG),
     ARGUMENT_ERROR(HttpStatus.BAD_REQUEST, "올바르지 않은 요청이 포함되었습니다.", LogLevel.DEBUG),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "요청 파라미터가 올바르지 않습니다.", LogLevel.DEBUG),
 

--- a/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
@@ -3,10 +3,11 @@ package dnd11th.blooming.common.exception
 import org.springframework.boot.logging.LogLevel
 import org.springframework.http.HttpStatus
 
-enum class ErrorType(val status: HttpStatus, val message: String, val logLevel: LogLevel) {
+enum class ErrorType(val status: HttpStatus, var message: String, val logLevel: LogLevel) {
     // COMMON
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error has occurred.", LogLevel.ERROR),
     INVALID_DATE(HttpStatus.BAD_REQUEST, "올바르지 않은 날짜입니다.", LogLevel.DEBUG),
+    ARGUMENT_ERROR(HttpStatus.BAD_REQUEST, "올바르지 않은 요청이 포함되었습니다.", LogLevel.DEBUG),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "요청 파라미터가 올바르지 않습니다.", LogLevel.DEBUG),
 
     // MyPlant

--- a/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
@@ -6,7 +6,6 @@ import org.springframework.http.HttpStatus
 enum class ErrorType(val status: HttpStatus, var message: String, val logLevel: LogLevel) {
     // COMMON
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error has occurred.", LogLevel.ERROR),
-    ARGUMENT_ERROR(HttpStatus.BAD_REQUEST, "올바르지 않은 요청이 포함되었습니다.", LogLevel.DEBUG),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "요청 파라미터가 올바르지 않습니다.", LogLevel.DEBUG),
 
     // MyPlant

--- a/src/main/kotlin/dnd11th/blooming/common/exception/FieldErrorResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/exception/FieldErrorResponse.kt
@@ -1,0 +1,6 @@
+package dnd11th.blooming.common.exception
+
+data class FieldErrorResponse(
+    val fieldName: String,
+    val message: String,
+)

--- a/src/main/kotlin/dnd11th/blooming/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/exception/GlobalExceptionHandler.kt
@@ -24,7 +24,7 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleArgumentValidationException(exception: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
-        val errorType = ErrorType.ARGUMENT_ERROR
+        val errorType = ErrorType.BAD_REQUEST
 
         // bindingResult를 순회하며 errorArgumentMap을 채운다.
         val fieldErrorList: List<FieldErrorResponse> =

--- a/src/main/kotlin/dnd11th/blooming/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/exception/GlobalExceptionHandler.kt
@@ -2,6 +2,8 @@ package dnd11th.blooming.common.exception
 
 import org.springframework.boot.logging.LogLevel
 import org.springframework.http.ResponseEntity
+import org.springframework.validation.FieldError
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
@@ -18,5 +20,30 @@ class GlobalExceptionHandler {
         return ResponseEntity
             .status(errorType.status)
             .body(ErrorResponse.from(errorType))
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleArgumentValidationException(exception: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
+        val errorType = ErrorType.ARGUMENT_ERROR
+        val errorArgumentMap = mutableMapOf<String, String>()
+
+        // bindingResult를 순회하며 errorArgumentMap을 채운다.
+        exception.bindingResult.allErrors
+            .forEach { error ->
+                run {
+                    val field = (error as? FieldError)?.field ?: return@forEach
+                    val message = error.defaultMessage ?: return@forEach
+                    errorArgumentMap[field] = message
+                }
+            }
+
+        // 가장 첫번째 bindingResult의 message를 예외의 message로 처리한다.
+        exception.bindingResult.allErrors[0].defaultMessage?.also {
+            errorType.message = it
+        }
+
+        return ResponseEntity
+            .status(exception.statusCode)
+            .body(ErrorResponse.from(ErrorType.ARGUMENT_ERROR, errorArgumentMap))
     }
 }

--- a/src/main/kotlin/dnd11th/blooming/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/exception/GlobalExceptionHandler.kt
@@ -28,7 +28,7 @@ class GlobalExceptionHandler {
 
         // bindingResult를 순회하며 errorArgumentMap을 채운다.
         val fieldErrorList: List<FieldErrorResponse> =
-            exception.bindingResult.allErrors
+            exception.bindingResult.allErrors.reversed()
                 .mapNotNull { error ->
                     val field = (error as? FieldError)?.field
                     val message = error?.defaultMessage
@@ -39,8 +39,8 @@ class GlobalExceptionHandler {
                     }
                 }
 
-        // 가장 첫번째 bindingResult의 message를 예외의 message로 처리한다.
-        exception.bindingResult.allErrors[0].defaultMessage?.also {
+        // 가장 처음 발생한 bindingResult의 message를 예외의 message로 처리한다.
+        exception.bindingResult.allErrors.last().defaultMessage?.also {
             errorType.message = it
         }
 

--- a/src/main/kotlin/dnd11th/blooming/common/exception/InvalidDateException.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/exception/InvalidDateException.kt
@@ -1,3 +1,0 @@
-package dnd11th.blooming.common.exception
-
-class InvalidDateException(errorType: ErrorType) : MyException(errorType)

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/BaseEntity.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/BaseEntity.kt
@@ -4,23 +4,23 @@ import jakarta.persistence.Column
 import jakarta.persistence.MappedSuperclass
 import jakarta.persistence.PrePersist
 import jakarta.persistence.PreUpdate
-import java.time.LocalDate
+import java.time.LocalDateTime
 
 @MappedSuperclass
 abstract class BaseEntity {
     @Column(name = "created_date", updatable = false)
-    var createdDate: LocalDate = LocalDate.now()
+    var createdDate: LocalDateTime = LocalDateTime.now()
 
     @Column(name = "updated_date")
-    var updatedDate: LocalDate = LocalDate.now()
+    var updatedDate: LocalDateTime = LocalDateTime.now()
 
     @PrePersist
     protected fun onCreate() {
-        createdDate = LocalDate.now()
+        createdDate = LocalDateTime.now()
     }
 
     @PreUpdate
     protected fun onUpdate() {
-        updatedDate = LocalDate.now()
+        updatedDate = LocalDateTime.now()
     }
 }

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/BaseEntity.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/BaseEntity.kt
@@ -2,16 +2,22 @@ package dnd11th.blooming.domain.entity
 
 import jakarta.persistence.Column
 import jakarta.persistence.MappedSuperclass
+import jakarta.persistence.PrePersist
 import jakarta.persistence.PreUpdate
 import java.time.LocalDate
 
 @MappedSuperclass
-abstract class BaseEntity(
+abstract class BaseEntity {
     @Column(name = "created_date", updatable = false)
-    var createdDate: LocalDate = LocalDate.now(),
-) {
+    var createdDate: LocalDate = LocalDate.now()
+
     @Column(name = "updated_date")
     var updatedDate: LocalDate = LocalDate.now()
+
+    @PrePersist
+    protected fun onCreate() {
+        createdDate = LocalDate.now()
+    }
 
     @PreUpdate
     protected fun onUpdate() {

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/Image.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/Image.kt
@@ -20,7 +20,7 @@ class Image(
 ) : BaseEntity(currentDate) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Long = 0
+    var id: Long? = null
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "myplant_id")

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/Image.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/Image.kt
@@ -1,5 +1,6 @@
 package dnd11th.blooming.domain.entity
 
+import dnd11th.blooming.api.dto.image.ImageCreateDto
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
@@ -26,11 +27,21 @@ class Image(
     @JoinColumn(name = "myplant_id")
     var myPlant: MyPlant? = null
 
-    fun setMyPlantRelation(myPlant: MyPlant) {
-        this.myPlant = myPlant
-    }
-
     fun modifyFavorite(favorite: Boolean) {
         this.favorite = favorite
+    }
+
+    companion object {
+        fun createImage(
+            dto: ImageCreateDto,
+            myPlant: MyPlant,
+            now: LocalDate,
+        ) = Image(
+            url = dto.url,
+            favorite = false,
+            currentDate = now,
+        ).also {
+            it.myPlant = myPlant
+        }
     }
 }

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/Image.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/Image.kt
@@ -9,7 +9,6 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
-import java.time.LocalDate
 
 @Entity
 class Image(
@@ -17,8 +16,7 @@ class Image(
     var url: String,
     @Column
     var favorite: Boolean,
-    currentDate: LocalDate = LocalDate.now(),
-) : BaseEntity(currentDate) {
+) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null
@@ -35,11 +33,9 @@ class Image(
         fun createImage(
             dto: ImageCreateDto,
             myPlant: MyPlant,
-            now: LocalDate,
         ) = Image(
             url = dto.url,
             favorite = false,
-            currentDate = now,
         ).also {
             it.myPlant = myPlant
         }

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/Location.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/Location.kt
@@ -19,7 +19,7 @@ class Location(
 ) : BaseEntity(currentDate) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Long = 0
+    var id: Long? = null
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/Location.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/Location.kt
@@ -10,14 +10,12 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
-import java.time.LocalDate
 
 @Entity
 class Location(
     @Column
     var name: String,
-    currentDate: LocalDate = LocalDate.now(),
-) : BaseEntity(currentDate) {
+) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null
@@ -31,13 +29,9 @@ class Location(
     }
 
     companion object {
-        fun createLocation(
-            dto: LocationCreateDto,
-            now: LocalDate,
-        ): Location =
+        fun createLocation(dto: LocationCreateDto): Location =
             Location(
                 name = dto.name,
-                currentDate = now,
             )
     }
 }

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/Location.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/Location.kt
@@ -1,5 +1,6 @@
 package dnd11th.blooming.domain.entity
 
+import dnd11th.blooming.api.dto.location.LocationCreateDto
 import dnd11th.blooming.domain.entity.user.User
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -27,5 +28,16 @@ class Location(
 
     fun modifyName(name: String) {
         this.name = name
+    }
+
+    companion object {
+        fun createLocation(
+            dto: LocationCreateDto,
+            now: LocalDate,
+        ): Location =
+            Location(
+                name = dto.name,
+                currentDate = now,
+            )
     }
 }

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/MyPlant.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/MyPlant.kt
@@ -31,7 +31,7 @@ class MyPlant(
 ) : BaseEntity(currentDate) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Long = 0
+    var id: Long? = null
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/MyPlant.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/MyPlant.kt
@@ -28,8 +28,7 @@ class MyPlant(
     var lastFertilizerDate: LocalDate = LocalDate.now(),
     @Embedded
     var alarm: Alarm,
-    currentDate: LocalDate = LocalDate.now(),
-) : BaseEntity(currentDate) {
+) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null
@@ -99,7 +98,6 @@ class MyPlant(
             dto: MyPlantCreateDto,
             location: Location,
             plant: String,
-            now: LocalDate,
         ): MyPlant =
             MyPlant(
                 scientificName = plant,
@@ -107,7 +105,6 @@ class MyPlant(
                 startDate = dto.startDate,
                 lastWateredDate = dto.lastWateredDate,
                 lastFertilizerDate = dto.lastFertilizerDate,
-                currentDate = now,
                 alarm =
                     Alarm(
                         waterAlarm = dto.waterAlarm,

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/MyPlant.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/MyPlant.kt
@@ -1,5 +1,6 @@
 package dnd11th.blooming.domain.entity
 
+import dnd11th.blooming.api.dto.myplant.MyPlantCreateDto
 import dnd11th.blooming.domain.entity.user.User
 import jakarta.persistence.Column
 import jakarta.persistence.Embedded
@@ -40,10 +41,6 @@ class MyPlant(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "location_id")
     var location: Location? = null
-
-    fun setLocationRelation(location: Location) {
-        this.location = location
-    }
 
     fun modify(
         nickname: String?,
@@ -95,5 +92,36 @@ class MyPlant(
 
     fun modifyHealthCheck(healthCheckAlarm: Boolean) {
         this.alarm.healthCheckAlarm = healthCheckAlarm
+    }
+
+    companion object {
+        fun createMyPlant(
+            dto: MyPlantCreateDto,
+            location: Location,
+            plant: String,
+            now: LocalDate,
+        ): MyPlant =
+            MyPlant(
+                scientificName = plant,
+                nickname = dto.nickname,
+                startDate = dto.startDate,
+                lastWateredDate = dto.lastWateredDate,
+                lastFertilizerDate = dto.lastFertilizerDate,
+                currentDate = now,
+                alarm =
+                    Alarm(
+                        waterAlarm = dto.waterAlarm,
+                        waterPeriod = dto.waterPeriod,
+                        fertilizerAlarm = dto.fertilizerAlarm,
+                        fertilizerPeriod = dto.fertilizerPeriod,
+                        healthCheckAlarm = dto.healthCheckAlarm,
+                    ),
+            ).also {
+                it.location = location
+                // it.plant = plant
+                // it.user = user
+                // TODO : 유저와 매핑 필요
+                // TODO : 식물가이드와 매핑 필요
+            }
     }
 }

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/user/User.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/user/User.kt
@@ -6,15 +6,13 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import java.time.LocalDate
 
 @Entity
 @Table(name = "users")
 class User(
     email: String,
     nickname: String,
-    currentDate: LocalDate = LocalDate.now(),
-) : BaseEntity(currentDate) {
+) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/user/UserOauthInfo.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/user/UserOauthInfo.kt
@@ -9,15 +9,13 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
-import java.time.LocalDate
 
 @Entity
 class UserOauthInfo(
     user: User,
     email: String,
     provider: OauthProvider,
-    currentDate: LocalDate = LocalDate.now(),
-) : BaseEntity(currentDate) {
+) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null

--- a/src/main/kotlin/dnd11th/blooming/domain/repository/ImageRepository.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/repository/ImageRepository.kt
@@ -1,5 +1,6 @@
 package dnd11th.blooming.domain.repository
 
+import dnd11th.blooming.api.dto.myplant.MyPlantIdWithImageUrl
 import dnd11th.blooming.domain.entity.Image
 import dnd11th.blooming.domain.entity.MyPlant
 import org.springframework.data.jpa.repository.JpaRepository
@@ -10,10 +11,27 @@ import org.springframework.data.repository.query.Param
 interface ImageRepository : JpaRepository<Image, Long> {
     fun findAllByMyPlant(myPlant: MyPlant): List<Image>
 
+    @Query(
+        """
+    SELECT new dnd11th.blooming.api.dto.myplant.MyPlantIdWithImageUrl(i.url, mp.id)
+    FROM Image i
+    JOIN i.myPlant mp
+    WHERE mp IN :myPlants
+    AND i.favorite = true
+    AND i.id = (
+        SELECT MIN(i2.id)
+        FROM Image i2
+        WHERE i2.myPlant = mp
+        AND i2.favorite = true
+    )
+	""",
+    )
+    fun findFavoriteImagesForMyPlants(myPlants: List<MyPlant>): List<MyPlantIdWithImageUrl>
+
     @Modifying
     @Query(
         """
-		DELETE FROM Image i WHERE i.myPlant = :myPlant
+	DELETE FROM Image i WHERE i.myPlant = :myPlant
 	""",
     )
     fun deleteAllInBatchByMyPlant(

--- a/src/test/kotlin/dnd11th/blooming/api/controller/home/HomeControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/home/HomeControllerTest.kt
@@ -10,10 +10,12 @@ import io.mockk.every
 import org.hamcrest.CoreMatchers.equalTo
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 
 @WebMvcTest(HomeController::class)
+@ActiveProfiles("test")
 class HomeControllerTest : DescribeSpec() {
     @MockkBean
     private lateinit var homeService: HomeService

--- a/src/test/kotlin/dnd11th/blooming/api/controller/image/ImageControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/image/ImageControllerValidationTest.kt
@@ -2,6 +2,7 @@ package dnd11th.blooming.api.controller.image
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
+import dnd11th.blooming.api.dto.image.ImageFavoriteModifyRequest
 import dnd11th.blooming.api.dto.image.ImageSaveRequest
 import dnd11th.blooming.api.service.image.ImageService
 import dnd11th.blooming.common.exception.ErrorType
@@ -12,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
 
 @WebMvcTest(ImageController::class)
@@ -30,6 +32,24 @@ class ImageControllerValidationTest : DescribeSpec() {
 
     init {
         describe("이미지 저장") {
+            context("이미지URL을 전달하지 않으면") {
+                val request =
+                    objectMapper.writeValueAsString(
+                        ImageSaveRequest(
+                            imageUrl = null,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/myplants/1/image") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = request
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("URL은 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
             context("이미지URL을 비우고 전달하면") {
                 val request =
                     objectMapper.writeValueAsString(
@@ -44,7 +64,28 @@ class ImageControllerValidationTest : DescribeSpec() {
                     }.andExpectAll {
                         status { isBadRequest() }
                         jsonPath("$.code", equalTo(ERROR_CODE))
-                        jsonPath("$.message", equalTo("URL은 비어있을 수 없습니다."))
+                        jsonPath("$.message", equalTo("URL은 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
+        }
+
+        describe("이미지 즐겨찾기 수정") {
+            context("즐겨찾기 여부를 전달하지 않으면") {
+                val request =
+                    objectMapper.writeValueAsString(
+                        ImageFavoriteModifyRequest(
+                            favorite = null,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.patch("/api/v1/myplants/image/1") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = request
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("즐겨찾기 여부는 필수값입니다."))
                     }.andDo { print() }
                 }
             }

--- a/src/test/kotlin/dnd11th/blooming/api/controller/image/ImageControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/image/ImageControllerValidationTest.kt
@@ -34,7 +34,7 @@ class ImageControllerValidationTest : DescribeSpec() {
                 val request =
                     objectMapper.writeValueAsString(
                         ImageSaveRequest(
-                            imageUrl = "",
+                            imageUrl = " ",
                         ),
                     )
                 it("예외 응답이 와야 한다.") {

--- a/src/test/kotlin/dnd11th/blooming/api/controller/image/ImageControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/image/ImageControllerValidationTest.kt
@@ -93,6 +93,6 @@ class ImageControllerValidationTest : DescribeSpec() {
     }
 
     companion object {
-        val ERROR_CODE = ErrorType.ARGUMENT_ERROR.name
+        val ERROR_CODE = ErrorType.BAD_REQUEST.name
     }
 }

--- a/src/test/kotlin/dnd11th/blooming/api/controller/image/ImageControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/image/ImageControllerValidationTest.kt
@@ -12,11 +12,13 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
 
 @WebMvcTest(ImageController::class)
+@ActiveProfiles("test")
 class ImageControllerValidationTest : DescribeSpec() {
     @MockkBean
     private lateinit var imageService: ImageService

--- a/src/test/kotlin/dnd11th/blooming/api/controller/image/ImageControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/image/ImageControllerValidationTest.kt
@@ -1,0 +1,57 @@
+package dnd11th.blooming.api.controller.image
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import dnd11th.blooming.api.dto.image.ImageSaveRequest
+import dnd11th.blooming.api.service.image.ImageService
+import dnd11th.blooming.common.exception.ErrorType
+import dnd11th.blooming.common.jwt.JwtProvider
+import io.kotest.core.spec.style.DescribeSpec
+import org.hamcrest.CoreMatchers.equalTo
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+
+@WebMvcTest(ImageController::class)
+class ImageControllerValidationTest : DescribeSpec() {
+    @MockkBean
+    private lateinit var imageService: ImageService
+
+    @MockkBean
+    private lateinit var jwtProvider: JwtProvider
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    init {
+        describe("이미지 저장") {
+            context("이미지URL을 비우고 전달하면") {
+                val request =
+                    objectMapper.writeValueAsString(
+                        ImageSaveRequest(
+                            imageUrl = "",
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/myplants/1/image") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = request
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("URL은 비어있을 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+        }
+    }
+
+    companion object {
+        val ERROR_CODE = ErrorType.ARGUMENT_ERROR.name
+    }
+}

--- a/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerTest.kt
@@ -106,7 +106,7 @@ class LocationControllerTest : DescribeSpec() {
                 val request =
                     objectMapper.writeValueAsString(
                         LocationModifyRequest(
-                            _name = LOCATION_NAME2,
+                            name = LOCATION_NAME2,
                         ),
                     )
                 it("수정된 위치가 반환되어야 한다.") {
@@ -124,7 +124,7 @@ class LocationControllerTest : DescribeSpec() {
                 val request =
                     objectMapper.writeValueAsString(
                         LocationModifyRequest(
-                            _name = LOCATION_NAME2,
+                            name = LOCATION_NAME2,
                         ),
                     )
                 it("예외 응답이 반환되어야 한다.") {

--- a/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerTest.kt
@@ -106,7 +106,7 @@ class LocationControllerTest : DescribeSpec() {
                 val request =
                     objectMapper.writeValueAsString(
                         LocationModifyRequest(
-                            name = LOCATION_NAME2,
+                            _name = LOCATION_NAME2,
                         ),
                     )
                 it("수정된 위치가 반환되어야 한다.") {
@@ -124,7 +124,7 @@ class LocationControllerTest : DescribeSpec() {
                 val request =
                     objectMapper.writeValueAsString(
                         LocationModifyRequest(
-                            name = LOCATION_NAME2,
+                            _name = LOCATION_NAME2,
                         ),
                     )
                 it("예외 응답이 반환되어야 한다.") {

--- a/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerTest.kt
@@ -18,6 +18,7 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
@@ -25,6 +26,7 @@ import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
 
 @WebMvcTest(LocationController::class)
+@ActiveProfiles("test")
 class LocationControllerTest : DescribeSpec() {
     @MockkBean
     private lateinit var locationService: LocationService

--- a/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerTest.kt
@@ -40,7 +40,7 @@ class LocationControllerTest : DescribeSpec() {
 
     init {
         describe("위치 저장") {
-            every { locationService.saveLocation(any()) } returns
+            every { locationService.saveLocation(any(), any()) } returns
                 LocationSaveResponse(
                     id = LOCATION_ID,
                     name = LOCATION_NAME,

--- a/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerTest.kt
@@ -42,7 +42,7 @@ class LocationControllerTest : DescribeSpec() {
 
     init {
         describe("위치 저장") {
-            every { locationService.saveLocation(any(), any()) } returns
+            every { locationService.saveLocation(any()) } returns
                 LocationSaveResponse(
                     id = LOCATION_ID,
                     name = LOCATION_NAME,

--- a/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerValidationTest.kt
@@ -1,0 +1,82 @@
+package dnd11th.blooming.api.controller.location
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import dnd11th.blooming.api.dto.location.LocationModifyRequest
+import dnd11th.blooming.api.dto.location.LocationSaveRequest
+import dnd11th.blooming.api.service.location.LocationService
+import dnd11th.blooming.common.exception.ErrorType
+import dnd11th.blooming.common.jwt.JwtProvider
+import io.kotest.core.spec.style.DescribeSpec
+import org.hamcrest.CoreMatchers.equalTo
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.patch
+import org.springframework.test.web.servlet.post
+
+@WebMvcTest(LocationController::class)
+class LocationControllerValidationTest : DescribeSpec() {
+    @MockkBean
+    private lateinit var locationService: LocationService
+
+    @MockkBean
+    private lateinit var jwtProvider: JwtProvider
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    init {
+        describe("위치 저장") {
+            context("위치명을 비우고 전달하면") {
+                val request =
+                    objectMapper.writeValueAsString(
+                        LocationSaveRequest(
+                            name = "",
+                        ),
+                    )
+                it("예외 응답이 반환되어야 한다.") {
+                    mockMvc.post("/api/v1/location") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = request
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("새로운 위치명은 비어있을 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+        }
+
+        describe("위치 이름 수정") {
+            context("위치명을 비우고 전달하면") {
+                val request =
+                    objectMapper.writeValueAsString(
+                        LocationModifyRequest(
+                            name = "",
+                        ),
+                    )
+                it("수정된 위치가 반환되어야 한다.") {
+                    mockMvc.patch("/api/v1/location/$LOCATION_ID") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = request
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("새로운 위치명은 비어있을 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+        }
+    }
+
+    companion object {
+        val ERROR_CODE = ErrorType.ARGUMENT_ERROR.name
+
+        const val LOCATION_ID = 1L
+    }
+}

--- a/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerValidationTest.kt
@@ -32,6 +32,24 @@ class LocationControllerValidationTest : DescribeSpec() {
 
     init {
         describe("위치 저장") {
+            context("위치명을 전달하지 않으면") {
+                val request =
+                    objectMapper.writeValueAsString(
+                        LocationSaveRequest(
+                            name = null,
+                        ),
+                    )
+                it("예외 응답이 반환되어야 한다.") {
+                    mockMvc.post("/api/v1/location") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = request
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("새로운 위치명은 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
             context("위치명을 비우고 전달하면") {
                 val request =
                     objectMapper.writeValueAsString(
@@ -46,18 +64,18 @@ class LocationControllerValidationTest : DescribeSpec() {
                     }.andExpectAll {
                         status { isBadRequest() }
                         jsonPath("$.code", equalTo(ERROR_CODE))
-                        jsonPath("$.message", equalTo("새로운 위치명은 비어있을 수 없습니다."))
+                        jsonPath("$.message", equalTo("새로운 위치명은 필수값입니다."))
                     }.andDo { print() }
                 }
             }
         }
 
         describe("위치 이름 수정") {
-            context("위치명을 비우고 전달하면") {
+            context("위치명을 전달하지 않으면") {
                 val request =
                     objectMapper.writeValueAsString(
                         LocationModifyRequest(
-                            _name = "",
+                            name = null,
                         ),
                     )
                 it("수정된 위치가 반환되어야 한다.") {
@@ -67,7 +85,25 @@ class LocationControllerValidationTest : DescribeSpec() {
                     }.andExpectAll {
                         status { isBadRequest() }
                         jsonPath("$.code", equalTo(ERROR_CODE))
-                        jsonPath("$.message", equalTo("새로운 위치명은 비어있을 수 없습니다."))
+                        jsonPath("$.message", equalTo("새로운 위치명은 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("위치명을 비우고 전달하면") {
+                val request =
+                    objectMapper.writeValueAsString(
+                        LocationModifyRequest(
+                            name = "",
+                        ),
+                    )
+                it("수정된 위치가 반환되어야 한다.") {
+                    mockMvc.patch("/api/v1/location/$LOCATION_ID") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = request
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("새로운 위치명은 필수값입니다."))
                     }.andDo { print() }
                 }
             }

--- a/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerValidationTest.kt
@@ -12,11 +12,13 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
 
 @WebMvcTest(LocationController::class)
+@ActiveProfiles("test")
 class LocationControllerValidationTest : DescribeSpec() {
     @MockkBean
     private lateinit var locationService: LocationService

--- a/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerValidationTest.kt
@@ -57,7 +57,7 @@ class LocationControllerValidationTest : DescribeSpec() {
                 val request =
                     objectMapper.writeValueAsString(
                         LocationModifyRequest(
-                            name = "",
+                            _name = "",
                         ),
                     )
                 it("수정된 위치가 반환되어야 한다.") {

--- a/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerValidationTest.kt
@@ -111,7 +111,7 @@ class LocationControllerValidationTest : DescribeSpec() {
     }
 
     companion object {
-        val ERROR_CODE = ErrorType.ARGUMENT_ERROR.name
+        val ERROR_CODE = ErrorType.BAD_REQUEST.name
 
         const val LOCATION_ID = 1L
     }

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
@@ -363,7 +363,7 @@ class MyPlantControllerTest : DescribeSpec() {
                 val request =
                     objectMapper.writeValueAsString(
                         MyPlantHealthCheckRequest(
-                            _healthCheck = true,
+                            healthCheck = true,
                         ),
                     )
                 it("정상 흐름이 반환된다.") {

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
@@ -22,6 +22,7 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
@@ -30,6 +31,7 @@ import org.springframework.test.web.servlet.post
 import java.time.LocalDate
 
 @WebMvcTest(MyPlantController::class)
+@ActiveProfiles("test")
 class MyPlantControllerTest : DescribeSpec() {
     @MockkBean
     private lateinit var myPlantService: MyPlantService

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
@@ -363,7 +363,7 @@ class MyPlantControllerTest : DescribeSpec() {
                 val request =
                     objectMapper.writeValueAsString(
                         MyPlantHealthCheckRequest(
-                            healthCheck = true,
+                            _healthCheck = true,
                         ),
                     )
                 it("정상 흐름이 반환된다.") {

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
@@ -87,6 +87,7 @@ class MyPlantControllerTest : DescribeSpec() {
                     MyPlantResponse(
                         myPlantId = MYPLANT_ID,
                         nickname = NICKNAME,
+                        imageUrl = IMAGE_URL,
                         scientificName = SCIENTIFIC_NAME,
                         waterRemainDay = WATER_REAMIN_DAY,
                         fertilizerRemainDay = FERTILIZER_REAMIN_DAY,
@@ -94,6 +95,7 @@ class MyPlantControllerTest : DescribeSpec() {
                     MyPlantResponse(
                         myPlantId = MYPLANT_ID2,
                         nickname = NICKNAME2,
+                        imageUrl = IMAGE_URL,
                         scientificName = SCIENTIFIC_NAME2,
                         waterRemainDay = WATER_REAMIN_DAY,
                         fertilizerRemainDay = FERTILIZER_REAMIN_DAY,
@@ -123,6 +125,7 @@ class MyPlantControllerTest : DescribeSpec() {
                     MyPlantResponse(
                         myPlantId = MYPLANT_ID,
                         nickname = NICKNAME,
+                        imageUrl = IMAGE_URL,
                         scientificName = SCIENTIFIC_NAME,
                         waterRemainDay = WATER_REAMIN_DAY,
                         fertilizerRemainDay = FERTILIZER_REAMIN_DAY,
@@ -431,6 +434,7 @@ class MyPlantControllerTest : DescribeSpec() {
         val CURRENT_DAY: LocalDate = LocalDate.now()
 
         const val PLANT_ID = 1L
+        const val IMAGE_URL = "http://"
 
         const val MYPLANT_ID = 1L
         const val SCIENTIFIC_NAME = "몬스테라 델리오사"

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
@@ -48,7 +48,7 @@ class MyPlantControllerTest : DescribeSpec() {
     init {
         describe("내 식물 저장") {
             beforeTest {
-                every { myPlantService.saveMyPlant(any(), any(), any()) } returns
+                every { myPlantService.saveMyPlant(any(), any()) } returns
                     MyPlantSaveResponse(
                         myPlantId = MYPLANT_ID,
                     )

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
@@ -46,7 +46,7 @@ class MyPlantControllerTest : DescribeSpec() {
     init {
         describe("내 식물 저장") {
             beforeTest {
-                every { myPlantService.saveMyPlant(any()) } returns
+                every { myPlantService.saveMyPlant(any(), any()) } returns
                     MyPlantSaveResponse(
                         myPlantId = MYPLANT_ID,
                     )

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
@@ -48,14 +48,14 @@ class MyPlantControllerTest : DescribeSpec() {
             beforeTest {
                 every { myPlantService.saveMyPlant(any()) } returns
                     MyPlantSaveResponse(
-                        myPlantId = ID,
+                        myPlantId = MYPLANT_ID,
                     )
             }
             context("정상적인 요청으로 저장하면") {
                 val json =
                     objectMapper.writeValueAsString(
                         MyPlantSaveRequest(
-                            scientificName = SCIENTIFIC_NAME,
+                            plantId = PLANT_ID,
                             nickname = NICKNAME,
                             locationId = LOCATION_ID,
                             startDate = START_DATE,
@@ -74,7 +74,7 @@ class MyPlantControllerTest : DescribeSpec() {
                         content = json
                     }.andExpectAll {
                         status { isOk() }
-                        jsonPath("$.myPlantId", equalTo(ID.toInt()))
+                        jsonPath("$.myPlantId", equalTo(MYPLANT_ID.toInt()))
                         jsonPath("$.message", equalTo("등록 되었습니다."))
                     }.andDo { print() }
                 }
@@ -85,14 +85,14 @@ class MyPlantControllerTest : DescribeSpec() {
             every { myPlantService.findAllMyPlant(any(), any(), any()) } returns
                 listOf(
                     MyPlantResponse(
-                        myPlantId = ID,
+                        myPlantId = MYPLANT_ID,
                         nickname = NICKNAME,
                         scientificName = SCIENTIFIC_NAME,
                         waterRemainDay = WATER_REAMIN_DAY,
                         fertilizerRemainDay = FERTILIZER_REAMIN_DAY,
                     ),
                     MyPlantResponse(
-                        myPlantId = ID2,
+                        myPlantId = MYPLANT_ID2,
                         nickname = NICKNAME2,
                         scientificName = SCIENTIFIC_NAME2,
                         waterRemainDay = WATER_REAMIN_DAY,
@@ -105,12 +105,12 @@ class MyPlantControllerTest : DescribeSpec() {
                         .andExpectAll {
                             status { isOk() }
                             jsonPath("$.size()", equalTo(2))
-                            jsonPath("$[0].myPlantId", equalTo(ID.toInt()))
+                            jsonPath("$[0].myPlantId", equalTo(MYPLANT_ID.toInt()))
                             jsonPath("$[0].nickname", equalTo(NICKNAME))
                             jsonPath("$[0].scientificName", equalTo(SCIENTIFIC_NAME))
                             jsonPath("$[0].waterRemainDay", equalTo(WATER_REAMIN_DAY))
                             jsonPath("$[0].fertilizerRemainDay", equalTo(FERTILIZER_REAMIN_DAY))
-                            jsonPath("$[1].myPlantId", equalTo(ID2.toInt()))
+                            jsonPath("$[1].myPlantId", equalTo(MYPLANT_ID2.toInt()))
                             jsonPath("$[1].nickname", equalTo(NICKNAME2))
                             jsonPath("$[1].scientificName", equalTo(SCIENTIFIC_NAME2))
                             jsonPath("$[1].waterRemainDay", equalTo(WATER_REAMIN_DAY))
@@ -121,7 +121,7 @@ class MyPlantControllerTest : DescribeSpec() {
             every { myPlantService.findAllMyPlant(any(), LOCATION_ID, any()) } returns
                 listOf(
                     MyPlantResponse(
-                        myPlantId = ID,
+                        myPlantId = MYPLANT_ID,
                         nickname = NICKNAME,
                         scientificName = SCIENTIFIC_NAME,
                         waterRemainDay = WATER_REAMIN_DAY,
@@ -136,7 +136,7 @@ class MyPlantControllerTest : DescribeSpec() {
                         .andExpectAll {
                             status { isOk() }
                             jsonPath("$.size()", equalTo(1))
-                            jsonPath("$[0].myPlantId", equalTo(ID.toInt()))
+                            jsonPath("$[0].myPlantId", equalTo(MYPLANT_ID.toInt()))
                             jsonPath("$[0].nickname", equalTo(NICKNAME))
                             jsonPath("$[0].scientificName", equalTo(SCIENTIFIC_NAME))
                             jsonPath("$[0].waterRemainDay", equalTo(WATER_REAMIN_DAY))
@@ -148,7 +148,7 @@ class MyPlantControllerTest : DescribeSpec() {
 
         describe("내 식물 상세 조회") {
             beforeTest {
-                every { myPlantService.findMyPlantDetail(ID, any()) } returns
+                every { myPlantService.findMyPlantDetail(MYPLANT_ID, any()) } returns
                     MyPlantDetailResponse(
                         nickname = NICKNAME,
                         scientificName = SCIENTIFIC_NAME,
@@ -177,12 +177,12 @@ class MyPlantControllerTest : DescribeSpec() {
                                 ),
                             ),
                     )
-                every { myPlantService.findMyPlantDetail(ID2, any()) } throws
+                every { myPlantService.findMyPlantDetail(MYPLANT_ID2, any()) } throws
                     NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
             }
             context("존재하는 ID로 조회하면") {
                 it("내 식물이 조회되어야 한다.") {
-                    mockMvc.get("/api/v1/plants/$ID")
+                    mockMvc.get("/api/v1/plants/$MYPLANT_ID")
                         .andExpectAll {
                             status { isOk() }
                             jsonPath("$.nickname", equalTo(NICKNAME))
@@ -206,7 +206,7 @@ class MyPlantControllerTest : DescribeSpec() {
             }
             context("존재하지 않는 ID로 조회하면") {
                 it("예외응답이 반한되어야 한다.") {
-                    mockMvc.get("/api/v1/plants/$ID2")
+                    mockMvc.get("/api/v1/plants/$MYPLANT_ID2")
                         .andExpectAll {
                             status { isNotFound() }
                             jsonPath("$.message", equalTo("존재하지 않는 내 식물입니다."))
@@ -219,7 +219,7 @@ class MyPlantControllerTest : DescribeSpec() {
         describe("내 식물 수정") {
             beforeTest {
                 every { myPlantService.modifyMyPlant(any(), any()) } just runs
-                every { myPlantService.modifyMyPlant(not(eq(ID)), any()) } throws
+                every { myPlantService.modifyMyPlant(not(eq(MYPLANT_ID)), any()) } throws
                     NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
                 every {
                     myPlantService.modifyMyPlant(
@@ -243,7 +243,7 @@ class MyPlantControllerTest : DescribeSpec() {
                         ),
                     )
                 it("정상 흐름이 반환되어야 한다.") {
-                    mockMvc.patch("/api/v1/plants/$ID") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID") {
                         contentType = MediaType.APPLICATION_JSON
                         content = request
                     }.andExpectAll {
@@ -263,7 +263,7 @@ class MyPlantControllerTest : DescribeSpec() {
                         ),
                     )
                 it("예외응답이 반환되어야 한다.") {
-                    mockMvc.patch("/api/v1/plants/$ID2") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID2") {
                         contentType = MediaType.APPLICATION_JSON
                         content = request
                     }.andExpectAll {
@@ -285,7 +285,7 @@ class MyPlantControllerTest : DescribeSpec() {
                         ),
                     )
                 it("예외응답이 반환되어야 한다.") {
-                    mockMvc.patch("/api/v1/plants/$ID2") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID2") {
                         contentType = MediaType.APPLICATION_JSON
                         content = request
                     }.andExpectAll {
@@ -300,12 +300,12 @@ class MyPlantControllerTest : DescribeSpec() {
         describe("내 식물 삭제") {
             beforeTest {
                 every { myPlantService.deleteMyPlant(any()) } just runs
-                every { myPlantService.deleteMyPlant(not(eq(ID))) } throws
+                every { myPlantService.deleteMyPlant(not(eq(MYPLANT_ID))) } throws
                     NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
             }
             context("정상 요청으로 삭제하면") {
                 it("정상 흐름이 반환되어야 한다.") {
-                    mockMvc.delete("/api/v1/plants/$ID")
+                    mockMvc.delete("/api/v1/plants/$MYPLANT_ID")
                         .andExpectAll {
                             status { isOk() }
                         }.andDo { print() }
@@ -313,7 +313,7 @@ class MyPlantControllerTest : DescribeSpec() {
             }
             context("존재하지 않는 내 식물 ID로 삭제하면") {
                 it("예외응답이 반환되어야 한다.") {
-                    mockMvc.delete("/api/v1/plants/$ID2")
+                    mockMvc.delete("/api/v1/plants/$MYPLANT_ID2")
                         .andExpectAll {
                             status { isNotFound() }
                             jsonPath("$.message", equalTo("존재하지 않는 내 식물입니다."))
@@ -330,7 +330,7 @@ class MyPlantControllerTest : DescribeSpec() {
             }
             context("물주기 요청을 하면") {
                 it("정상 흐름이 반환된다.") {
-                    mockMvc.post("/api/v1/plants/$ID/water")
+                    mockMvc.post("/api/v1/plants/$MYPLANT_ID/water")
                         .andExpectAll {
                             status { isOk() }
                         }.andDo { print() }
@@ -344,7 +344,7 @@ class MyPlantControllerTest : DescribeSpec() {
             }
             context("물주기 요청을 하면") {
                 it("정상 흐름이 반환된다.") {
-                    mockMvc.post("/api/v1/plants/$ID/fertilizer")
+                    mockMvc.post("/api/v1/plants/$MYPLANT_ID/fertilizer")
                         .andExpectAll {
                             status { isOk() }
                         }.andDo { print() }
@@ -364,7 +364,7 @@ class MyPlantControllerTest : DescribeSpec() {
                         ),
                     )
                 it("정상 흐름이 반환된다.") {
-                    mockMvc.patch("/api/v1/plants/$ID/healthcheck") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID/healthcheck") {
                         contentType = MediaType.APPLICATION_JSON
                         content = request
                     }.andExpectAll {
@@ -376,8 +376,8 @@ class MyPlantControllerTest : DescribeSpec() {
 
         describe("내 식물의 알림 수정") {
             beforeTest {
-                every { myPlantService.modifyMyPlantAlarm(ID, any()) } just runs
-                every { myPlantService.modifyMyPlantAlarm(not(eq(ID)), any()) } throws
+                every { myPlantService.modifyMyPlantAlarm(MYPLANT_ID, any()) } just runs
+                every { myPlantService.modifyMyPlantAlarm(not(eq(MYPLANT_ID)), any()) } throws
                     NotFoundException(ErrorType.NOT_FOUND_MYPLANT)
             }
             context("존재하는 ID로 수정하면") {
@@ -392,7 +392,7 @@ class MyPlantControllerTest : DescribeSpec() {
                         ),
                     )
                 it("정상응답이 반환되어야 한다.") {
-                    mockMvc.patch("/api/v1/plants/$ID/alarm") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID/alarm") {
                         contentType = MediaType.APPLICATION_JSON
                         content = json
                     }
@@ -413,7 +413,7 @@ class MyPlantControllerTest : DescribeSpec() {
                         ),
                     )
                 it("예외응답이 반환되어야 한다.") {
-                    mockMvc.patch("/api/v1/plants/$ID2/alarm") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID2/alarm") {
                         contentType = MediaType.APPLICATION_JSON
                         content = json
                     }
@@ -430,7 +430,9 @@ class MyPlantControllerTest : DescribeSpec() {
     companion object {
         val CURRENT_DAY: LocalDate = LocalDate.now()
 
-        const val ID = 1L
+        const val PLANT_ID = 1L
+
+        const val MYPLANT_ID = 1L
         const val SCIENTIFIC_NAME = "몬스테라 델리오사"
         const val NICKNAME = "뿡뿡이"
         const val LOCATION_ID = 100L
@@ -441,7 +443,7 @@ class MyPlantControllerTest : DescribeSpec() {
         const val WATER_REAMIN_DAY = 3
         const val FERTILIZER_REAMIN_DAY = 3
 
-        const val ID2 = 2L
+        const val MYPLANT_ID2 = 2L
         const val SCIENTIFIC_NAME2 = "병아리 눈물"
         const val NICKNAME2 = "빵빵이"
 

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
@@ -48,7 +48,7 @@ class MyPlantControllerTest : DescribeSpec() {
     init {
         describe("내 식물 저장") {
             beforeTest {
-                every { myPlantService.saveMyPlant(any(), any()) } returns
+                every { myPlantService.saveMyPlant(any(), any(), any()) } returns
                     MyPlantSaveResponse(
                         myPlantId = MYPLANT_ID,
                     )

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
@@ -33,39 +33,11 @@ class MyPlantControllerValidationTest : DescribeSpec() {
 
     init {
         describe("내 식물 저장") {
-            context("식물 종류를 비우고 전달하면") {
-                val json =
-                    objectMapper.writeValueAsString(
-                        MyPlantSaveRequest(
-                            scientificName = " ",
-                            nickname = NICKNAME,
-                            locationId = LOCATION_ID,
-                            startDate = START_DATE,
-                            lastWateredDate = LAST_WATERED_DATE,
-                            lastFertilizerDate = LAST_FERTILIZER_DATE,
-                            waterAlarm = WATER_ALARM,
-                            waterPeriod = WATER_PERIOD,
-                            fertilizerAlarm = FERTILIZER_ALARM,
-                            fertilizerPeriod = FERTILIZER_PERIOD,
-                            healthCheckAlarm = HEALTHCHECK_ALARM,
-                        ),
-                    )
-                it("예외 응답이 와야 한다.") {
-                    mockMvc.post("/api/v1/plants") {
-                        contentType = MediaType.APPLICATION_JSON
-                        content = json
-                    }.andExpectAll {
-                        status { isBadRequest() }
-                        jsonPath("$.code", equalTo(ERROR_CODE))
-                        jsonPath("$.message", equalTo("식물 종류는 비어있을 수 없습니다."))
-                    }.andDo { print() }
-                }
-            }
             context("식물 별명을 비우고 전달하면") {
                 val json =
                     objectMapper.writeValueAsString(
                         MyPlantSaveRequest(
-                            scientificName = SCIENTIFIC_NAME,
+                            plantId = PLANT_ID,
                             nickname = " ",
                             locationId = LOCATION_ID,
                             startDate = START_DATE,
@@ -93,7 +65,7 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                 val json =
                     objectMapper.writeValueAsString(
                         MyPlantSaveRequest(
-                            scientificName = SCIENTIFIC_NAME,
+                            plantId = PLANT_ID,
                             nickname = NICKNAME,
                             locationId = LOCATION_ID,
                             startDate = FUTURE_DATE,
@@ -121,7 +93,7 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                 val json =
                     objectMapper.writeValueAsString(
                         MyPlantSaveRequest(
-                            scientificName = SCIENTIFIC_NAME,
+                            plantId = PLANT_ID,
                             nickname = NICKNAME,
                             locationId = LOCATION_ID,
                             startDate = START_DATE,
@@ -149,7 +121,7 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                 val json =
                     objectMapper.writeValueAsString(
                         MyPlantSaveRequest(
-                            scientificName = SCIENTIFIC_NAME,
+                            plantId = PLANT_ID,
                             nickname = NICKNAME,
                             locationId = LOCATION_ID,
                             startDate = START_DATE,
@@ -188,7 +160,7 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                         ),
                     )
                 it("예외 응답이 와야 한다.") {
-                    mockMvc.patch("/api/v1/plants/$PLANT_ID") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID") {
                         contentType = MediaType.APPLICATION_JSON
                         content = json
                     }.andExpectAll {
@@ -210,7 +182,7 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                         ),
                     )
                 it("예외 응답이 와야 한다.") {
-                    mockMvc.patch("/api/v1/plants/$PLANT_ID") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID") {
                         contentType = MediaType.APPLICATION_JSON
                         content = json
                     }.andExpectAll {
@@ -232,7 +204,7 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                         ),
                     )
                 it("예외 응답이 와야 한다.") {
-                    mockMvc.patch("/api/v1/plants/$PLANT_ID") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID") {
                         contentType = MediaType.APPLICATION_JSON
                         content = json
                     }.andExpectAll {
@@ -254,7 +226,7 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                         ),
                     )
                 it("예외 응답이 와야 한다.") {
-                    mockMvc.patch("/api/v1/plants/$PLANT_ID") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID") {
                         contentType = MediaType.APPLICATION_JSON
                         content = json
                     }.andExpectAll {
@@ -270,6 +242,7 @@ class MyPlantControllerValidationTest : DescribeSpec() {
     companion object {
         val ERROR_CODE = ErrorType.ARGUMENT_ERROR.name
         const val PLANT_ID = 1L
+        const val MYPLANT_ID = 1L
         const val SCIENTIFIC_NAME = "몬스테라 델리오사"
         const val NICKNAME = "뿡뿡이"
         const val LOCATION_ID = 100L

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
@@ -1,0 +1,78 @@
+package dnd11th.blooming.api.controller.myplant
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import dnd11th.blooming.api.dto.myplant.MyPlantSaveRequest
+import dnd11th.blooming.api.service.myplant.MyPlantService
+import dnd11th.blooming.common.exception.ErrorType
+import dnd11th.blooming.common.jwt.JwtProvider
+import io.kotest.core.spec.style.DescribeSpec
+import org.hamcrest.CoreMatchers.equalTo
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import java.time.LocalDate
+
+@WebMvcTest(MyPlantController::class)
+class MyPlantControllerValidationTest : DescribeSpec() {
+    @MockkBean
+    private lateinit var myPlantService: MyPlantService
+
+    @MockkBean
+    private lateinit var jwtProvider: JwtProvider
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    init {
+        describe("내 식물 저장") {
+            context("식물 종류를 비우고 전달하면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantSaveRequest(
+                            scientificName = "",
+                            nickname = NICKNAME,
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/plants") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("식물 종류는 비어있을 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+        }
+    }
+
+    companion object {
+        val ERROR_CODE = ErrorType.ARGUMENT_ERROR.name
+        const val NICKNAME = "뿡뿡이"
+        const val LOCATION_ID = 100L
+        val START_DATE: LocalDate = LocalDate.of(2024, 4, 19)
+        val LAST_WATERED_DATE: LocalDate = LocalDate.of(2024, 6, 29)
+        val LAST_FERTILIZER_DATE: LocalDate = LocalDate.of(2024, 6, 15)
+        const val WATER_ALARM = true
+        const val WATER_PERIOD = 3
+        const val FERTILIZER_ALARM = false
+        const val FERTILIZER_PERIOD = 30
+        const val HEALTHCHECK_ALARM = true
+    }
+}

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
@@ -14,12 +14,14 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
 import java.time.LocalDate
 
 @WebMvcTest(MyPlantController::class)
+@ActiveProfiles("test")
 class MyPlantControllerValidationTest : DescribeSpec() {
     @MockkBean
     private lateinit var myPlantService: MyPlantService

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
@@ -2,6 +2,7 @@ package dnd11th.blooming.api.controller.myplant
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
+import dnd11th.blooming.api.dto.myplant.MyPlantModifyRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantSaveRequest
 import dnd11th.blooming.api.service.myplant.MyPlantService
 import dnd11th.blooming.common.exception.ErrorType
@@ -12,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
 import java.time.LocalDate
 
@@ -35,7 +37,7 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                 val json =
                     objectMapper.writeValueAsString(
                         MyPlantSaveRequest(
-                            scientificName = "",
+                            scientificName = " ",
                             nickname = NICKNAME,
                             locationId = LOCATION_ID,
                             startDate = START_DATE,
@@ -59,13 +61,219 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                     }.andDo { print() }
                 }
             }
+            context("식물 별명을 비우고 전달하면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantSaveRequest(
+                            scientificName = SCIENTIFIC_NAME,
+                            nickname = " ",
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/plants") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("식물 별명은 비어있을 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("키우기 시작한 날짜를 미래로 전달하면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantSaveRequest(
+                            scientificName = SCIENTIFIC_NAME,
+                            nickname = NICKNAME,
+                            locationId = LOCATION_ID,
+                            startDate = FUTURE_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/plants") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("키우기 시작한 날짜는 미래일 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("마지막으로 물 준 날짜를 미래로 전달하면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantSaveRequest(
+                            scientificName = SCIENTIFIC_NAME,
+                            nickname = NICKNAME,
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = FUTURE_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/plants") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("마지막으로 물 준 날짜는 미래일 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("마지막으로 비료 준 날짜를 미래로 전달하면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantSaveRequest(
+                            scientificName = SCIENTIFIC_NAME,
+                            nickname = NICKNAME,
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = FUTURE_DATE,
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/plants") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("마지막으로 비료 준 날짜는 미래일 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+        }
+
+        describe("내 식물 수정") {
+            context("식물 별명을 비우고 전달하면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantModifyRequest(
+                            nickname = " ",
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.patch("/api/v1/plants/$PLANT_ID") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("식물 별명은 비어있을 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("키우기 시작한 날짜를 미래로 전달하면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantModifyRequest(
+                            nickname = NICKNAME,
+                            locationId = LOCATION_ID,
+                            startDate = FUTURE_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.patch("/api/v1/plants/$PLANT_ID") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("키우기 시작한 날짜는 미래일 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("마지막으로 물 준 날짜를 미래로 전달하면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantModifyRequest(
+                            nickname = NICKNAME,
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = FUTURE_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.patch("/api/v1/plants/$PLANT_ID") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("마지막으로 물 준 날짜는 미래일 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("마지막으로 비료 준 날짜를 미래로 전달하면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantModifyRequest(
+                            nickname = NICKNAME,
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = FUTURE_DATE,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.patch("/api/v1/plants/$PLANT_ID") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("마지막으로 비료 준 날짜는 미래일 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
         }
     }
 
     companion object {
         val ERROR_CODE = ErrorType.ARGUMENT_ERROR.name
+        const val PLANT_ID = 1L
+        const val SCIENTIFIC_NAME = "몬스테라 델리오사"
         const val NICKNAME = "뿡뿡이"
         const val LOCATION_ID = 100L
+        val FUTURE_DATE: LocalDate = LocalDate.now().plusDays(1)
         val START_DATE: LocalDate = LocalDate.of(2024, 4, 19)
         val LAST_WATERED_DATE: LocalDate = LocalDate.of(2024, 6, 29)
         val LAST_FERTILIZER_DATE: LocalDate = LocalDate.of(2024, 6, 15)

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
@@ -148,28 +148,6 @@ class MyPlantControllerValidationTest : DescribeSpec() {
         }
 
         describe("내 식물 수정") {
-            context("식물 별명을 비우고 전달하면") {
-                val json =
-                    objectMapper.writeValueAsString(
-                        MyPlantModifyRequest(
-                            nickname = " ",
-                            locationId = LOCATION_ID,
-                            startDate = START_DATE,
-                            lastWateredDate = LAST_WATERED_DATE,
-                            lastFertilizerDate = LAST_FERTILIZER_DATE,
-                        ),
-                    )
-                it("예외 응답이 와야 한다.") {
-                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID") {
-                        contentType = MediaType.APPLICATION_JSON
-                        content = json
-                    }.andExpectAll {
-                        status { isBadRequest() }
-                        jsonPath("$.code", equalTo(ERROR_CODE))
-                        jsonPath("$.message", equalTo("식물 별명은 비어있을 수 없습니다."))
-                    }.andDo { print() }
-                }
-            }
             context("키우기 시작한 날짜를 미래로 전달하면") {
                 val json =
                     objectMapper.writeValueAsString(

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
@@ -478,7 +478,7 @@ class MyPlantControllerValidationTest : DescribeSpec() {
     }
 
     companion object {
-        val ERROR_CODE = ErrorType.ARGUMENT_ERROR.name
+        val ERROR_CODE = ErrorType.BAD_REQUEST.name
         const val PLANT_ID = 1L
         const val MYPLANT_ID = 1L
         const val SCIENTIFIC_NAME = "몬스테라 델리오사"

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
@@ -2,6 +2,8 @@ package dnd11th.blooming.api.controller.myplant
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
+import dnd11th.blooming.api.dto.myplant.AlarmModifyRequest
+import dnd11th.blooming.api.dto.myplant.MyPlantHealthCheckRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantModifyRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantSaveRequest
 import dnd11th.blooming.api.service.myplant.MyPlantService
@@ -33,6 +35,62 @@ class MyPlantControllerValidationTest : DescribeSpec() {
 
     init {
         describe("내 식물 저장") {
+            context("식물종류를 전달하지 않으면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantSaveRequest(
+                            plantId = null,
+                            nickname = NICKNAME,
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/plants") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("식물 종류는 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("식물 별명을 전달하지 않으면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantSaveRequest(
+                            plantId = PLANT_ID,
+                            nickname = null,
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/plants") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("식물 별명은 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
             context("식물 별명을 비우고 전달하면") {
                 val json =
                     objectMapper.writeValueAsString(
@@ -57,7 +115,35 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                     }.andExpectAll {
                         status { isBadRequest() }
                         jsonPath("$.code", equalTo(ERROR_CODE))
-                        jsonPath("$.message", equalTo("식물 별명은 비어있을 수 없습니다."))
+                        jsonPath("$.message", equalTo("식물 별명은 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("식물위치를 전달하지 않으면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantSaveRequest(
+                            plantId = PLANT_ID,
+                            nickname = NICKNAME,
+                            locationId = null,
+                            startDate = START_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/plants") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("위치는 필수값입니다."))
                     }.andDo { print() }
                 }
             }
@@ -142,6 +228,90 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                         status { isBadRequest() }
                         jsonPath("$.code", equalTo(ERROR_CODE))
                         jsonPath("$.message", equalTo("마지막으로 비료 준 날짜는 미래일 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("물주기 알림 여부를 전달하지 않으면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantSaveRequest(
+                            plantId = PLANT_ID,
+                            nickname = NICKNAME,
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                            waterAlarm = null,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/plants") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("물주기 알림 여부는 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("비료주기 알림 여부를 전달하지 않으면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantSaveRequest(
+                            plantId = PLANT_ID,
+                            nickname = NICKNAME,
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = null,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/plants") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("비료주기 알림 여부는 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("건강확인 알림 여부를 전달하지 않으면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantSaveRequest(
+                            plantId = PLANT_ID,
+                            nickname = NICKNAME,
+                            locationId = LOCATION_ID,
+                            startDate = START_DATE,
+                            lastWateredDate = LAST_WATERED_DATE,
+                            lastFertilizerDate = LAST_FERTILIZER_DATE,
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = null,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.post("/api/v1/plants") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("건강확인 알림 여부는 필수값입니다."))
                     }.andDo { print() }
                 }
             }
@@ -211,6 +381,96 @@ class MyPlantControllerValidationTest : DescribeSpec() {
                         status { isBadRequest() }
                         jsonPath("$.code", equalTo(ERROR_CODE))
                         jsonPath("$.message", equalTo("마지막으로 비료 준 날짜는 미래일 수 없습니다."))
+                    }.andDo { print() }
+                }
+            }
+        }
+
+        describe("내 식물 알림 수정") {
+            context("물주기 알림 여부를 전달하지 않으면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        AlarmModifyRequest(
+                            waterAlarm = null,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID/alarm") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("물주기 알림 여부는 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("비료주기 알림 여부를 전달하지 않으면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        AlarmModifyRequest(
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = null,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = HEALTHCHECK_ALARM,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID/alarm") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("비료주기 알림 여부는 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
+            context("건강확인 알림 여부를 전달하지 않으면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        AlarmModifyRequest(
+                            waterAlarm = WATER_ALARM,
+                            waterPeriod = WATER_PERIOD,
+                            fertilizerAlarm = FERTILIZER_ALARM,
+                            fertilizerPeriod = FERTILIZER_PERIOD,
+                            healthCheckAlarm = null,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID/alarm") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("건강확인 알림 여부는 필수값입니다."))
+                    }.andDo { print() }
+                }
+            }
+        }
+
+        describe("내 식물 건강확인") {
+            context("건강확인 알림 여부를 전달하지 않으면") {
+                val json =
+                    objectMapper.writeValueAsString(
+                        MyPlantHealthCheckRequest(
+                            healthCheck = null,
+                        ),
+                    )
+                it("예외 응답이 와야 한다.") {
+                    mockMvc.patch("/api/v1/plants/$MYPLANT_ID/healthcheck") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = json
+                    }.andExpectAll {
+                        status { isBadRequest() }
+                        jsonPath("$.code", equalTo(ERROR_CODE))
+                        jsonPath("$.message", equalTo("건강확인 알림 여부는 필수값입니다."))
                     }.andDo { print() }
                 }
             }

--- a/src/test/kotlin/dnd11th/blooming/api/service/home/HomeServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/home/HomeServiceTest.kt
@@ -24,7 +24,6 @@ class HomeServiceTest : DescribeSpec(
                 MyPlant(
                     scientificName = "병아리눈물",
                     nickname = "일번",
-                    currentDate = LocalDate.of(2024, 5, 15),
                     lastWateredDate = LocalDate.of(2024, 5, 16),
                     alarm = ALARM,
                 ).apply {
@@ -35,7 +34,6 @@ class HomeServiceTest : DescribeSpec(
                 MyPlant(
                     scientificName = "몬스테라 델리오사",
                     nickname = "이번",
-                    currentDate = LocalDate.of(2024, 5, 16),
                     lastWateredDate = LocalDate.of(2024, 5, 17),
                     alarm = ALARM,
                 ).apply {
@@ -46,7 +44,6 @@ class HomeServiceTest : DescribeSpec(
                 MyPlant(
                     scientificName = "선인장",
                     nickname = "삼번",
-                    currentDate = LocalDate.of(2024, 5, 17),
                     lastWateredDate = LocalDate.of(2024, 5, 15),
                     alarm = ALARM,
                 ).apply {

--- a/src/test/kotlin/dnd11th/blooming/api/service/location/LocationServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/location/LocationServiceTest.kt
@@ -34,7 +34,7 @@ class LocationServiceTest : DescribeSpec(
                         name = "거실",
                     )
                 it("위치가 저장되어야 한다.") {
-                    val response = locationService.saveLocation(request, CURRENT_DAY)
+                    val response = locationService.saveLocation(request)
 
                     response.id shouldBe LOCATION_ID
                     response.name shouldBe LOCATION_NAME

--- a/src/test/kotlin/dnd11th/blooming/api/service/location/LocationServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/location/LocationServiceTest.kt
@@ -82,7 +82,7 @@ class LocationServiceTest : DescribeSpec(
             context("존재하는 ID의 위치를 수정하면") {
                 val request =
                     LocationModifyRequest(
-                        name = MODIFIED_LOCATION_NAME,
+                        _name = MODIFIED_LOCATION_NAME,
                     )
                 it("위치가 수정되고, 수정된 위치가 조회되어야 한다.") {
                     val response = locationService.modifyLocation(LOCATION_ID, request)
@@ -93,7 +93,7 @@ class LocationServiceTest : DescribeSpec(
             context("존재하지 않는 ID의 위치를 수정하면") {
                 val request =
                     LocationModifyRequest(
-                        name = MODIFIED_LOCATION_NAME,
+                        _name = MODIFIED_LOCATION_NAME,
                     )
                 it("NotFoundException(NOT_FOUND_LOCATION_ID) 예외가 발생해야 한다.") {
                     val exception =

--- a/src/test/kotlin/dnd11th/blooming/api/service/location/LocationServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/location/LocationServiceTest.kt
@@ -82,7 +82,7 @@ class LocationServiceTest : DescribeSpec(
             context("존재하는 ID의 위치를 수정하면") {
                 val request =
                     LocationModifyRequest(
-                        _name = MODIFIED_LOCATION_NAME,
+                        name = MODIFIED_LOCATION_NAME,
                     )
                 it("위치가 수정되고, 수정된 위치가 조회되어야 한다.") {
                     val response = locationService.modifyLocation(LOCATION_ID, request)
@@ -93,7 +93,7 @@ class LocationServiceTest : DescribeSpec(
             context("존재하지 않는 ID의 위치를 수정하면") {
                 val request =
                     LocationModifyRequest(
-                        _name = MODIFIED_LOCATION_NAME,
+                        name = MODIFIED_LOCATION_NAME,
                     )
                 it("NotFoundException(NOT_FOUND_LOCATION_ID) 예외가 발생해야 한다.") {
                     val exception =

--- a/src/test/kotlin/dnd11th/blooming/api/service/location/LocationServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/location/LocationServiceTest.kt
@@ -1,7 +1,7 @@
 package dnd11th.blooming.api.service.location
 
+import dnd11th.blooming.api.dto.location.LocationCreateDto
 import dnd11th.blooming.api.dto.location.LocationModifyRequest
-import dnd11th.blooming.api.dto.location.LocationSaveRequest
 import dnd11th.blooming.common.exception.ErrorType
 import dnd11th.blooming.common.exception.NotFoundException
 import dnd11th.blooming.domain.entity.Location
@@ -30,7 +30,7 @@ class LocationServiceTest : DescribeSpec(
                 }
             context("name이 전달되면") {
                 val request =
-                    LocationSaveRequest(
+                    LocationCreateDto(
                         name = "거실",
                     )
                 it("위치가 저장되어야 한다.") {

--- a/src/test/kotlin/dnd11th/blooming/api/service/location/LocationServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/location/LocationServiceTest.kt
@@ -14,6 +14,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import org.springframework.data.repository.findByIdOrNull
+import java.time.LocalDate
 
 class LocationServiceTest : DescribeSpec(
     {
@@ -33,7 +34,7 @@ class LocationServiceTest : DescribeSpec(
                         name = "거실",
                     )
                 it("위치가 저장되어야 한다.") {
-                    val response = locationService.saveLocation(request)
+                    val response = locationService.saveLocation(request, CURRENT_DAY)
 
                     response.id shouldBe LOCATION_ID
                     response.name shouldBe LOCATION_NAME
@@ -131,6 +132,7 @@ class LocationServiceTest : DescribeSpec(
     },
 ) {
     companion object {
+        val CURRENT_DAY: LocalDate = LocalDate.of(2024, 5, 17)
         const val LOCATION_ID = 1L
         const val LOCATION_ID2 = 2L
         const val LOCATION_NAME = "거실"

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceIntegrationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceIntegrationTest.kt
@@ -1,0 +1,477 @@
+package dnd11th.blooming.api.service.myplant
+
+import dnd11th.blooming.api.dto.myplant.MyPlantQueryCreteria
+import dnd11th.blooming.domain.entity.Alarm
+import dnd11th.blooming.domain.entity.Image
+import dnd11th.blooming.domain.entity.Location
+import dnd11th.blooming.domain.entity.MyPlant
+import dnd11th.blooming.domain.repository.ImageRepository
+import dnd11th.blooming.domain.repository.LocationRepository
+import dnd11th.blooming.domain.repository.MyPlantRepository
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.time.LocalDate
+
+@SpringBootTest
+class MyPlantServiceIntegrationTest : DescribeSpec() {
+    @Autowired
+    lateinit var myPlantService: MyPlantService
+
+    @Autowired
+    lateinit var myPlantRepository: MyPlantRepository
+
+    @Autowired
+    lateinit var imageRepository: ImageRepository
+
+    @Autowired
+    lateinit var locationRepository: LocationRepository
+
+    init {
+        describe("최근생성순 식물 전체 조회") {
+            val location =
+                locationRepository.save(
+                    Location(
+                        name = "장소명",
+                        currentDate = CURRENT_DAY,
+                    ),
+                )
+
+            val recentPlant =
+                myPlantRepository.save(
+                    MyPlant(
+                        scientificName = "학명1",
+                        nickname = "별명1",
+                        startDate = CURRENT_DAY,
+                        lastWateredDate = CURRENT_DAY,
+                        lastFertilizerDate = CURRENT_DAY,
+                        alarm = Alarm(),
+                        currentDate = CURRENT_DAY.minusDays(5),
+                    ).also {
+                        it.setLocationRelation(location)
+                    },
+                )
+
+            val latePlant =
+                myPlantRepository.save(
+                    MyPlant(
+                        scientificName = "학명2",
+                        nickname = "별명2",
+                        startDate = CURRENT_DAY,
+                        lastWateredDate = CURRENT_DAY,
+                        lastFertilizerDate = CURRENT_DAY,
+                        alarm = Alarm(),
+                        currentDate = CURRENT_DAY.minusDays(10),
+                    ).also {
+                        it.setLocationRelation(location)
+                    },
+                )
+
+            val image1 =
+                imageRepository.save(
+                    Image(
+                        url = "url1",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image2 =
+                imageRepository.save(
+                    Image(
+                        url = "url2",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image3 =
+                imageRepository.save(
+                    Image(
+                        url = "url3",
+                        favorite = false,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image4 =
+                imageRepository.save(
+                    Image(
+                        url = "url4",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(latePlant)
+                    },
+                )
+
+            val image5 =
+                imageRepository.save(
+                    Image(
+                        url = "url5",
+                        favorite = false,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(latePlant)
+                    },
+                )
+            context("식물 전체 조회를 하면") {
+                val result =
+                    myPlantService.findAllMyPlant(
+                        now = CURRENT_DAY,
+                        locationId = location.id,
+                        sort = MyPlantQueryCreteria.CreatedDesc,
+                    )
+
+                it("식물 정보와 인삿말과 imageUrl이 잘 조회된다.") {
+                    result.size shouldBe 2
+                    result[0].nickname shouldBe recentPlant.nickname
+                    result[0].imageUrl shouldBe image1.url
+                    result[1].nickname shouldBe latePlant.nickname
+                    result[1].imageUrl shouldBe image4.url
+                }
+            }
+        }
+        describe("오래된 생성순 식물 전체 조회") {
+            val location =
+                locationRepository.save(
+                    Location(
+                        name = "장소명",
+                        currentDate = CURRENT_DAY,
+                    ),
+                )
+
+            val recentPlant =
+                myPlantRepository.save(
+                    MyPlant(
+                        scientificName = "학명1",
+                        nickname = "별명1",
+                        startDate = CURRENT_DAY,
+                        lastWateredDate = CURRENT_DAY,
+                        lastFertilizerDate = CURRENT_DAY,
+                        alarm = Alarm(),
+                        currentDate = CURRENT_DAY.minusDays(5),
+                    ).also {
+                        it.setLocationRelation(location)
+                    },
+                )
+
+            val latePlant =
+                myPlantRepository.save(
+                    MyPlant(
+                        scientificName = "학명2",
+                        nickname = "별명2",
+                        startDate = CURRENT_DAY,
+                        lastWateredDate = CURRENT_DAY,
+                        lastFertilizerDate = CURRENT_DAY,
+                        alarm = Alarm(),
+                        currentDate = CURRENT_DAY.minusDays(10),
+                    ).also {
+                        it.setLocationRelation(location)
+                    },
+                )
+
+            val image1 =
+                imageRepository.save(
+                    Image(
+                        url = "url1",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image2 =
+                imageRepository.save(
+                    Image(
+                        url = "url2",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image3 =
+                imageRepository.save(
+                    Image(
+                        url = "url3",
+                        favorite = false,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image4 =
+                imageRepository.save(
+                    Image(
+                        url = "url4",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(latePlant)
+                    },
+                )
+
+            val image5 =
+                imageRepository.save(
+                    Image(
+                        url = "url5",
+                        favorite = false,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(latePlant)
+                    },
+                )
+            context("식물 전체 조회를 하면") {
+                val result =
+                    myPlantService.findAllMyPlant(
+                        now = CURRENT_DAY,
+                        locationId = location.id,
+                        sort = MyPlantQueryCreteria.CreatedAsc,
+                    )
+
+                it("식물 정보와 인삿말과 imageUrl이 잘 조회된다.") {
+                    result.size shouldBe 2
+                    result[0].nickname shouldBe latePlant.nickname
+                    result[0].imageUrl shouldBe image4.url
+                    result[1].nickname shouldBe recentPlant.nickname
+                    result[1].imageUrl shouldBe image1.url
+                }
+            }
+        }
+        describe("최근 물주기순 식물 전체 조회") {
+            val location =
+                locationRepository.save(
+                    Location(
+                        name = "장소명",
+                        currentDate = CURRENT_DAY,
+                    ),
+                )
+
+            val recentPlant =
+                myPlantRepository.save(
+                    MyPlant(
+                        scientificName = "학명1",
+                        nickname = "별명1",
+                        startDate = CURRENT_DAY,
+                        lastWateredDate = CURRENT_DAY.minusDays(5),
+                        lastFertilizerDate = CURRENT_DAY,
+                        alarm = Alarm(),
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setLocationRelation(location)
+                    },
+                )
+
+            val latePlant =
+                myPlantRepository.save(
+                    MyPlant(
+                        scientificName = "학명2",
+                        nickname = "별명2",
+                        startDate = CURRENT_DAY,
+                        lastWateredDate = CURRENT_DAY.minusDays(10),
+                        lastFertilizerDate = CURRENT_DAY,
+                        alarm = Alarm(),
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setLocationRelation(location)
+                    },
+                )
+
+            val image1 =
+                imageRepository.save(
+                    Image(
+                        url = "url1",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image2 =
+                imageRepository.save(
+                    Image(
+                        url = "url2",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image3 =
+                imageRepository.save(
+                    Image(
+                        url = "url3",
+                        favorite = false,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image4 =
+                imageRepository.save(
+                    Image(
+                        url = "url4",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(latePlant)
+                    },
+                )
+
+            val image5 =
+                imageRepository.save(
+                    Image(
+                        url = "url5",
+                        favorite = false,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(latePlant)
+                    },
+                )
+            context("식물 전체 조회를 하면") {
+                val result =
+                    myPlantService.findAllMyPlant(
+                        now = CURRENT_DAY,
+                        locationId = location.id,
+                        sort = MyPlantQueryCreteria.WateredDesc,
+                    )
+
+                it("식물 정보와 인삿말과 imageUrl이 잘 조회된다.") {
+                    result.size shouldBe 2
+                    result[0].nickname shouldBe recentPlant.nickname
+                    result[0].imageUrl shouldBe image1.url
+                    result[1].nickname shouldBe latePlant.nickname
+                    result[1].imageUrl shouldBe image4.url
+                }
+            }
+        }
+        describe("오래된 물주기순 식물 전체 조회") {
+            val location =
+                locationRepository.save(
+                    Location(
+                        name = "장소명",
+                        currentDate = CURRENT_DAY,
+                    ),
+                )
+
+            val recentPlant =
+                myPlantRepository.save(
+                    MyPlant(
+                        scientificName = "학명1",
+                        nickname = "별명1",
+                        startDate = CURRENT_DAY,
+                        lastWateredDate = CURRENT_DAY.minusDays(5),
+                        lastFertilizerDate = CURRENT_DAY,
+                        alarm = Alarm(),
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setLocationRelation(location)
+                    },
+                )
+
+            val latePlant =
+                myPlantRepository.save(
+                    MyPlant(
+                        scientificName = "학명2",
+                        nickname = "별명2",
+                        startDate = CURRENT_DAY,
+                        lastWateredDate = CURRENT_DAY.minusDays(10),
+                        lastFertilizerDate = CURRENT_DAY,
+                        alarm = Alarm(),
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setLocationRelation(location)
+                    },
+                )
+
+            val image1 =
+                imageRepository.save(
+                    Image(
+                        url = "url1",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image2 =
+                imageRepository.save(
+                    Image(
+                        url = "url2",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image3 =
+                imageRepository.save(
+                    Image(
+                        url = "url3",
+                        favorite = false,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(recentPlant)
+                    },
+                )
+
+            val image4 =
+                imageRepository.save(
+                    Image(
+                        url = "url4",
+                        favorite = true,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(latePlant)
+                    },
+                )
+
+            val image5 =
+                imageRepository.save(
+                    Image(
+                        url = "url5",
+                        favorite = false,
+                        currentDate = CURRENT_DAY,
+                    ).also {
+                        it.setMyPlantRelation(latePlant)
+                    },
+                )
+            context("식물 전체 조회를 하면") {
+                val result =
+                    myPlantService.findAllMyPlant(
+                        now = CURRENT_DAY,
+                        locationId = location.id,
+                        sort = MyPlantQueryCreteria.WateredAsc,
+                    )
+
+                it("식물 정보와 인삿말과 imageUrl이 잘 조회된다.") {
+                    result.size shouldBe 2
+                    result[0].nickname shouldBe latePlant.nickname
+                    result[0].imageUrl shouldBe image4.url
+                    result[1].nickname shouldBe recentPlant.nickname
+                    result[1].imageUrl shouldBe image1.url
+                }
+            }
+        }
+    }
+
+    companion object {
+        val CURRENT_DAY: LocalDate = LocalDate.of(2000, 5, 17)
+    }
+}

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceIntegrationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceIntegrationTest.kt
@@ -29,6 +29,12 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
     lateinit var locationRepository: LocationRepository
 
     init {
+        afterTest {
+            imageRepository.deleteAllInBatch()
+            myPlantRepository.deleteAllInBatch()
+            locationRepository.deleteAllInBatch()
+        }
+
         describe("최근생성순 식물 전체 조회") {
             val location =
                 locationRepository.save(

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceIntegrationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceIntegrationTest.kt
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -42,46 +43,61 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                 locationRepository.save(
                     Location(
                         name = "장소명",
-                        currentDate = CURRENT_DAY,
                     ),
+                )
+
+            val pastPlant =
+                myPlantRepository.save(
+                    MyPlant(
+                        scientificName = "학명1",
+                        nickname = "별명1",
+                        startDate = DATE_TIME,
+                        lastWateredDate = DATE_TIME,
+                        lastFertilizerDate = DATE_TIME,
+                        alarm = Alarm(),
+                    ).also {
+                        it.location = location
+                    },
                 )
 
             val recentPlant =
                 myPlantRepository.save(
                     MyPlant(
-                        scientificName = "학명1",
-                        nickname = "별명1",
-                        startDate = CURRENT_DAY,
-                        lastWateredDate = CURRENT_DAY,
-                        lastFertilizerDate = CURRENT_DAY,
-                        alarm = Alarm(),
-                        currentDate = CURRENT_DAY.minusDays(5),
-                    ).also {
-                        it.location = location
-                    },
-                )
-
-            val latePlant =
-                myPlantRepository.save(
-                    MyPlant(
                         scientificName = "학명2",
                         nickname = "별명2",
-                        startDate = CURRENT_DAY,
-                        lastWateredDate = CURRENT_DAY,
-                        lastFertilizerDate = CURRENT_DAY,
+                        startDate = DATE_TIME,
+                        lastWateredDate = DATE_TIME,
+                        lastFertilizerDate = DATE_TIME,
                         alarm = Alarm(),
-                        currentDate = CURRENT_DAY.minusDays(10),
                     ).also {
                         it.location = location
                     },
                 )
 
-            val image1 =
+            val pastImage =
+                imageRepository.save(
+                    Image(
+                        url = "url4",
+                        favorite = true,
+                    ).also {
+                        it.myPlant = pastPlant
+                    },
+                )
+
+            imageRepository.save(
+                Image(
+                    url = "url5",
+                    favorite = false,
+                ).also {
+                    it.myPlant = pastPlant
+                },
+            )
+
+            val recentImage =
                 imageRepository.save(
                     Image(
                         url = "url1",
                         favorite = true,
-                        currentDate = CURRENT_DAY,
                     ).also {
                         it.myPlant = recentPlant
                     },
@@ -91,7 +107,6 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                 Image(
                     url = "url2",
                     favorite = true,
-                    currentDate = CURRENT_DAY,
                 ).also {
                     it.myPlant = recentPlant
                 },
@@ -101,36 +116,14 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                 Image(
                     url = "url3",
                     favorite = false,
-                    currentDate = CURRENT_DAY,
                 ).also {
                     it.myPlant = recentPlant
                 },
             )
-
-            val image4 =
-                imageRepository.save(
-                    Image(
-                        url = "url4",
-                        favorite = true,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.myPlant = latePlant
-                    },
-                )
-
-            imageRepository.save(
-                Image(
-                    url = "url5",
-                    favorite = false,
-                    currentDate = CURRENT_DAY,
-                ).also {
-                    it.myPlant = latePlant
-                },
-            )
-            context("식물 전체 조회를 하면") {
+            context("최근생성순 식물 전체 조회를 하면") {
                 val result =
                     myPlantService.findAllMyPlant(
-                        now = CURRENT_DAY,
+                        now = DATE_TIME,
                         locationId = location.id,
                         sort = MyPlantQueryCreteria.CreatedDesc,
                     )
@@ -138,9 +131,9 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                 it("식물 정보와 인삿말과 imageUrl이 잘 조회된다.") {
                     result.size shouldBe 2
                     result[0].nickname shouldBe recentPlant.nickname
-                    result[0].imageUrl shouldBe image1.url
-                    result[1].nickname shouldBe latePlant.nickname
-                    result[1].imageUrl shouldBe image4.url
+                    result[0].imageUrl shouldBe recentImage.url
+                    result[1].nickname shouldBe pastPlant.nickname
+                    result[1].imageUrl shouldBe pastImage.url
                 }
             }
         }
@@ -149,46 +142,61 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                 locationRepository.save(
                     Location(
                         name = "장소명",
-                        currentDate = CURRENT_DAY,
                     ),
+                )
+
+            val pastPlant =
+                myPlantRepository.save(
+                    MyPlant(
+                        scientificName = "학명1",
+                        nickname = "별명1",
+                        startDate = DATE_TIME,
+                        lastWateredDate = DATE_TIME,
+                        lastFertilizerDate = DATE_TIME,
+                        alarm = Alarm(),
+                    ).also {
+                        it.location = location
+                    },
                 )
 
             val recentPlant =
                 myPlantRepository.save(
                     MyPlant(
-                        scientificName = "학명1",
-                        nickname = "별명1",
-                        startDate = CURRENT_DAY,
-                        lastWateredDate = CURRENT_DAY,
-                        lastFertilizerDate = CURRENT_DAY,
-                        alarm = Alarm(),
-                        currentDate = CURRENT_DAY.minusDays(5),
-                    ).also {
-                        it.location = location
-                    },
-                )
-
-            val latePlant =
-                myPlantRepository.save(
-                    MyPlant(
                         scientificName = "학명2",
                         nickname = "별명2",
-                        startDate = CURRENT_DAY,
-                        lastWateredDate = CURRENT_DAY,
-                        lastFertilizerDate = CURRENT_DAY,
+                        startDate = DATE_TIME,
+                        lastWateredDate = DATE_TIME,
+                        lastFertilizerDate = DATE_TIME,
                         alarm = Alarm(),
-                        currentDate = CURRENT_DAY.minusDays(10),
                     ).also {
                         it.location = location
                     },
                 )
 
-            val image1 =
+            val pastImage =
+                imageRepository.save(
+                    Image(
+                        url = "url4",
+                        favorite = true,
+                    ).also {
+                        it.myPlant = pastPlant
+                    },
+                )
+
+            imageRepository.save(
+                Image(
+                    url = "url5",
+                    favorite = false,
+                ).also {
+                    it.myPlant = pastPlant
+                },
+            )
+
+            val recentImage =
                 imageRepository.save(
                     Image(
                         url = "url1",
                         favorite = true,
-                        currentDate = CURRENT_DAY,
                     ).also {
                         it.myPlant = recentPlant
                     },
@@ -198,7 +206,6 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                 Image(
                     url = "url2",
                     favorite = true,
-                    currentDate = CURRENT_DAY,
                 ).also {
                     it.myPlant = recentPlant
                 },
@@ -208,46 +215,24 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                 Image(
                     url = "url3",
                     favorite = false,
-                    currentDate = CURRENT_DAY,
                 ).also {
                     it.myPlant = recentPlant
                 },
             )
-
-            val image4 =
-                imageRepository.save(
-                    Image(
-                        url = "url4",
-                        favorite = true,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.myPlant = latePlant
-                    },
-                )
-
-            imageRepository.save(
-                Image(
-                    url = "url5",
-                    favorite = false,
-                    currentDate = CURRENT_DAY,
-                ).also {
-                    it.myPlant = latePlant
-                },
-            )
-            context("식물 전체 조회를 하면") {
+            context("오래된 생성순 식물 전체 조회를 하면") {
                 val result =
                     myPlantService.findAllMyPlant(
-                        now = CURRENT_DAY,
+                        now = DATE_TIME,
                         locationId = location.id,
                         sort = MyPlantQueryCreteria.CreatedAsc,
                     )
 
                 it("식물 정보와 인삿말과 imageUrl이 잘 조회된다.") {
                     result.size shouldBe 2
-                    result[0].nickname shouldBe latePlant.nickname
-                    result[0].imageUrl shouldBe image4.url
+                    result[0].nickname shouldBe pastPlant.nickname
+                    result[0].imageUrl shouldBe pastImage.url
                     result[1].nickname shouldBe recentPlant.nickname
-                    result[1].imageUrl shouldBe image1.url
+                    result[1].imageUrl shouldBe recentImage.url
                 }
             }
         }
@@ -256,7 +241,6 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                 locationRepository.save(
                     Location(
                         name = "장소명",
-                        currentDate = CURRENT_DAY,
                     ),
                 )
 
@@ -265,37 +249,34 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     MyPlant(
                         scientificName = "학명1",
                         nickname = "별명1",
-                        startDate = CURRENT_DAY,
-                        lastWateredDate = CURRENT_DAY.minusDays(5),
-                        lastFertilizerDate = CURRENT_DAY,
+                        startDate = DATE_TIME,
+                        lastWateredDate = DATE_TIME.minusDays(5),
+                        lastFertilizerDate = DATE_TIME,
                         alarm = Alarm(),
-                        currentDate = CURRENT_DAY,
                     ).also {
                         it.location = location
                     },
                 )
 
-            val latePlant =
+            val pastPlant =
                 myPlantRepository.save(
                     MyPlant(
                         scientificName = "학명2",
                         nickname = "별명2",
-                        startDate = CURRENT_DAY,
-                        lastWateredDate = CURRENT_DAY.minusDays(10),
-                        lastFertilizerDate = CURRENT_DAY,
+                        startDate = DATE_TIME,
+                        lastWateredDate = DATE_TIME.minusDays(10),
+                        lastFertilizerDate = DATE_TIME,
                         alarm = Alarm(),
-                        currentDate = CURRENT_DAY,
                     ).also {
                         it.location = location
                     },
                 )
 
-            val image1 =
+            val recentImage =
                 imageRepository.save(
                     Image(
                         url = "url1",
                         favorite = true,
-                        currentDate = CURRENT_DAY,
                     ).also {
                         it.myPlant = recentPlant
                     },
@@ -305,7 +286,6 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                 Image(
                     url = "url2",
                     favorite = true,
-                    currentDate = CURRENT_DAY,
                 ).also {
                     it.myPlant = recentPlant
                 },
@@ -315,20 +295,18 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                 Image(
                     url = "url3",
                     favorite = false,
-                    currentDate = CURRENT_DAY,
                 ).also {
                     it.myPlant = recentPlant
                 },
             )
 
-            val image4 =
+            val pastImage =
                 imageRepository.save(
                     Image(
                         url = "url4",
                         favorite = true,
-                        currentDate = CURRENT_DAY,
                     ).also {
-                        it.myPlant = latePlant
+                        it.myPlant = pastPlant
                     },
                 )
 
@@ -336,15 +314,14 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                 Image(
                     url = "url5",
                     favorite = false,
-                    currentDate = CURRENT_DAY,
                 ).also {
-                    it.myPlant = latePlant
+                    it.myPlant = pastPlant
                 },
             )
             context("식물 전체 조회를 하면") {
                 val result =
                     myPlantService.findAllMyPlant(
-                        now = CURRENT_DAY,
+                        now = DATE_TIME,
                         locationId = location.id,
                         sort = MyPlantQueryCreteria.WateredDesc,
                     )
@@ -352,9 +329,9 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                 it("식물 정보와 인삿말과 imageUrl이 잘 조회된다.") {
                     result.size shouldBe 2
                     result[0].nickname shouldBe recentPlant.nickname
-                    result[0].imageUrl shouldBe image1.url
-                    result[1].nickname shouldBe latePlant.nickname
-                    result[1].imageUrl shouldBe image4.url
+                    result[0].imageUrl shouldBe recentImage.url
+                    result[1].nickname shouldBe pastPlant.nickname
+                    result[1].imageUrl shouldBe pastImage.url
                 }
             }
         }
@@ -363,7 +340,6 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                 locationRepository.save(
                     Location(
                         name = "장소명",
-                        currentDate = CURRENT_DAY,
                     ),
                 )
 
@@ -372,37 +348,34 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     MyPlant(
                         scientificName = "학명1",
                         nickname = "별명1",
-                        startDate = CURRENT_DAY,
-                        lastWateredDate = CURRENT_DAY.minusDays(5),
-                        lastFertilizerDate = CURRENT_DAY,
+                        startDate = DATE_TIME,
+                        lastWateredDate = DATE_TIME.minusDays(5),
+                        lastFertilizerDate = DATE_TIME,
                         alarm = Alarm(),
-                        currentDate = CURRENT_DAY,
                     ).also {
                         it.location = location
                     },
                 )
 
-            val latePlant =
+            val pastPlant =
                 myPlantRepository.save(
                     MyPlant(
                         scientificName = "학명2",
                         nickname = "별명2",
-                        startDate = CURRENT_DAY,
-                        lastWateredDate = CURRENT_DAY.minusDays(10),
-                        lastFertilizerDate = CURRENT_DAY,
+                        startDate = DATE_TIME,
+                        lastWateredDate = DATE_TIME.minusDays(10),
+                        lastFertilizerDate = DATE_TIME,
                         alarm = Alarm(),
-                        currentDate = CURRENT_DAY,
                     ).also {
                         it.location = location
                     },
                 )
 
-            val image1 =
+            val recentImage =
                 imageRepository.save(
                     Image(
                         url = "url1",
                         favorite = true,
-                        currentDate = CURRENT_DAY,
                     ).also {
                         it.myPlant = recentPlant
                     },
@@ -412,7 +385,6 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                 Image(
                     url = "url2",
                     favorite = true,
-                    currentDate = CURRENT_DAY,
                 ).also {
                     it.myPlant = recentPlant
                 },
@@ -422,20 +394,18 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                 Image(
                     url = "url3",
                     favorite = false,
-                    currentDate = CURRENT_DAY,
                 ).also {
                     it.myPlant = recentPlant
                 },
             )
 
-            val image4 =
+            val pastImage =
                 imageRepository.save(
                     Image(
                         url = "url4",
                         favorite = true,
-                        currentDate = CURRENT_DAY,
                     ).also {
-                        it.myPlant = latePlant
+                        it.myPlant = pastPlant
                     },
                 )
 
@@ -443,31 +413,31 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                 Image(
                     url = "url5",
                     favorite = false,
-                    currentDate = CURRENT_DAY,
                 ).also {
-                    it.myPlant = latePlant
+                    it.myPlant = pastPlant
                 },
             )
             context("식물 전체 조회를 하면") {
                 val result =
                     myPlantService.findAllMyPlant(
-                        now = CURRENT_DAY,
+                        now = DATE_TIME,
                         locationId = location.id,
                         sort = MyPlantQueryCreteria.WateredAsc,
                     )
 
                 it("식물 정보와 인삿말과 imageUrl이 잘 조회된다.") {
                     result.size shouldBe 2
-                    result[0].nickname shouldBe latePlant.nickname
-                    result[0].imageUrl shouldBe image4.url
+                    result[0].nickname shouldBe pastPlant.nickname
+                    result[0].imageUrl shouldBe pastImage.url
                     result[1].nickname shouldBe recentPlant.nickname
-                    result[1].imageUrl shouldBe image1.url
+                    result[1].imageUrl shouldBe recentImage.url
                 }
             }
         }
     }
 
     companion object {
-        val CURRENT_DAY: LocalDate = LocalDate.of(2000, 5, 17)
+        val CURRENT_TIME: LocalDateTime = LocalDateTime.of(2000, 5, 17, 12, 0, 0)
+        val DATE_TIME: LocalDate = CURRENT_TIME.toLocalDate().minusDays(10)
     }
 }

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceIntegrationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceIntegrationTest.kt
@@ -55,7 +55,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                         alarm = Alarm(),
                         currentDate = CURRENT_DAY.minusDays(5),
                     ).also {
-                        it.setLocationRelation(location)
+                        it.location = location
                     },
                 )
 
@@ -70,7 +70,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                         alarm = Alarm(),
                         currentDate = CURRENT_DAY.minusDays(10),
                     ).also {
-                        it.setLocationRelation(location)
+                        it.location = location
                     },
                 )
 
@@ -81,7 +81,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                         favorite = true,
                         currentDate = CURRENT_DAY,
                     ).also {
-                        it.setMyPlantRelation(recentPlant)
+                        it.myPlant = recentPlant
                     },
                 )
 
@@ -91,7 +91,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     favorite = true,
                     currentDate = CURRENT_DAY,
                 ).also {
-                    it.setMyPlantRelation(recentPlant)
+                    it.myPlant = recentPlant
                 },
             )
 
@@ -101,7 +101,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     favorite = false,
                     currentDate = CURRENT_DAY,
                 ).also {
-                    it.setMyPlantRelation(recentPlant)
+                    it.myPlant = recentPlant
                 },
             )
 
@@ -112,7 +112,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                         favorite = true,
                         currentDate = CURRENT_DAY,
                     ).also {
-                        it.setMyPlantRelation(latePlant)
+                        it.myPlant = latePlant
                     },
                 )
 
@@ -122,7 +122,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     favorite = false,
                     currentDate = CURRENT_DAY,
                 ).also {
-                    it.setMyPlantRelation(latePlant)
+                    it.myPlant = latePlant
                 },
             )
             context("식물 전체 조회를 하면") {
@@ -162,7 +162,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                         alarm = Alarm(),
                         currentDate = CURRENT_DAY.minusDays(5),
                     ).also {
-                        it.setLocationRelation(location)
+                        it.location = location
                     },
                 )
 
@@ -177,7 +177,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                         alarm = Alarm(),
                         currentDate = CURRENT_DAY.minusDays(10),
                     ).also {
-                        it.setLocationRelation(location)
+                        it.location = location
                     },
                 )
 
@@ -188,7 +188,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                         favorite = true,
                         currentDate = CURRENT_DAY,
                     ).also {
-                        it.setMyPlantRelation(recentPlant)
+                        it.myPlant = recentPlant
                     },
                 )
 
@@ -198,7 +198,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     favorite = true,
                     currentDate = CURRENT_DAY,
                 ).also {
-                    it.setMyPlantRelation(recentPlant)
+                    it.myPlant = recentPlant
                 },
             )
 
@@ -208,7 +208,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     favorite = false,
                     currentDate = CURRENT_DAY,
                 ).also {
-                    it.setMyPlantRelation(recentPlant)
+                    it.myPlant = recentPlant
                 },
             )
 
@@ -219,7 +219,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                         favorite = true,
                         currentDate = CURRENT_DAY,
                     ).also {
-                        it.setMyPlantRelation(latePlant)
+                        it.myPlant = latePlant
                     },
                 )
 
@@ -229,7 +229,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     favorite = false,
                     currentDate = CURRENT_DAY,
                 ).also {
-                    it.setMyPlantRelation(latePlant)
+                    it.myPlant = latePlant
                 },
             )
             context("식물 전체 조회를 하면") {
@@ -269,7 +269,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                         alarm = Alarm(),
                         currentDate = CURRENT_DAY,
                     ).also {
-                        it.setLocationRelation(location)
+                        it.location = location
                     },
                 )
 
@@ -284,7 +284,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                         alarm = Alarm(),
                         currentDate = CURRENT_DAY,
                     ).also {
-                        it.setLocationRelation(location)
+                        it.location = location
                     },
                 )
 
@@ -295,7 +295,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                         favorite = true,
                         currentDate = CURRENT_DAY,
                     ).also {
-                        it.setMyPlantRelation(recentPlant)
+                        it.myPlant = recentPlant
                     },
                 )
 
@@ -305,7 +305,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     favorite = true,
                     currentDate = CURRENT_DAY,
                 ).also {
-                    it.setMyPlantRelation(recentPlant)
+                    it.myPlant = recentPlant
                 },
             )
 
@@ -315,7 +315,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     favorite = false,
                     currentDate = CURRENT_DAY,
                 ).also {
-                    it.setMyPlantRelation(recentPlant)
+                    it.myPlant = recentPlant
                 },
             )
 
@@ -326,7 +326,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                         favorite = true,
                         currentDate = CURRENT_DAY,
                     ).also {
-                        it.setMyPlantRelation(latePlant)
+                        it.myPlant = latePlant
                     },
                 )
 
@@ -336,7 +336,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     favorite = false,
                     currentDate = CURRENT_DAY,
                 ).also {
-                    it.setMyPlantRelation(latePlant)
+                    it.myPlant = latePlant
                 },
             )
             context("식물 전체 조회를 하면") {
@@ -376,7 +376,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                         alarm = Alarm(),
                         currentDate = CURRENT_DAY,
                     ).also {
-                        it.setLocationRelation(location)
+                        it.location = location
                     },
                 )
 
@@ -391,7 +391,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                         alarm = Alarm(),
                         currentDate = CURRENT_DAY,
                     ).also {
-                        it.setLocationRelation(location)
+                        it.location = location
                     },
                 )
 
@@ -402,7 +402,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                         favorite = true,
                         currentDate = CURRENT_DAY,
                     ).also {
-                        it.setMyPlantRelation(recentPlant)
+                        it.myPlant = recentPlant
                     },
                 )
 
@@ -412,7 +412,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     favorite = true,
                     currentDate = CURRENT_DAY,
                 ).also {
-                    it.setMyPlantRelation(recentPlant)
+                    it.myPlant = recentPlant
                 },
             )
 
@@ -422,7 +422,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     favorite = false,
                     currentDate = CURRENT_DAY,
                 ).also {
-                    it.setMyPlantRelation(recentPlant)
+                    it.myPlant = recentPlant
                 },
             )
 
@@ -433,7 +433,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                         favorite = true,
                         currentDate = CURRENT_DAY,
                     ).also {
-                        it.setMyPlantRelation(latePlant)
+                        it.myPlant = latePlant
                     },
                 )
 
@@ -443,7 +443,7 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     favorite = false,
                     currentDate = CURRENT_DAY,
                 ).also {
-                    it.setMyPlantRelation(latePlant)
+                    it.myPlant = latePlant
                 },
             )
             context("식물 전체 조회를 하면") {

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceIntegrationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceIntegrationTest.kt
@@ -85,27 +85,25 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     },
                 )
 
-            val image2 =
-                imageRepository.save(
-                    Image(
-                        url = "url2",
-                        favorite = true,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(recentPlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url2",
+                    favorite = true,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(recentPlant)
+                },
+            )
 
-            val image3 =
-                imageRepository.save(
-                    Image(
-                        url = "url3",
-                        favorite = false,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(recentPlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url3",
+                    favorite = false,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(recentPlant)
+                },
+            )
 
             val image4 =
                 imageRepository.save(
@@ -118,16 +116,15 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     },
                 )
 
-            val image5 =
-                imageRepository.save(
-                    Image(
-                        url = "url5",
-                        favorite = false,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(latePlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url5",
+                    favorite = false,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(latePlant)
+                },
+            )
             context("식물 전체 조회를 하면") {
                 val result =
                     myPlantService.findAllMyPlant(
@@ -195,27 +192,25 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     },
                 )
 
-            val image2 =
-                imageRepository.save(
-                    Image(
-                        url = "url2",
-                        favorite = true,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(recentPlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url2",
+                    favorite = true,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(recentPlant)
+                },
+            )
 
-            val image3 =
-                imageRepository.save(
-                    Image(
-                        url = "url3",
-                        favorite = false,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(recentPlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url3",
+                    favorite = false,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(recentPlant)
+                },
+            )
 
             val image4 =
                 imageRepository.save(
@@ -228,16 +223,15 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     },
                 )
 
-            val image5 =
-                imageRepository.save(
-                    Image(
-                        url = "url5",
-                        favorite = false,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(latePlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url5",
+                    favorite = false,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(latePlant)
+                },
+            )
             context("식물 전체 조회를 하면") {
                 val result =
                     myPlantService.findAllMyPlant(
@@ -305,27 +299,25 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     },
                 )
 
-            val image2 =
-                imageRepository.save(
-                    Image(
-                        url = "url2",
-                        favorite = true,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(recentPlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url2",
+                    favorite = true,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(recentPlant)
+                },
+            )
 
-            val image3 =
-                imageRepository.save(
-                    Image(
-                        url = "url3",
-                        favorite = false,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(recentPlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url3",
+                    favorite = false,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(recentPlant)
+                },
+            )
 
             val image4 =
                 imageRepository.save(
@@ -338,16 +330,15 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     },
                 )
 
-            val image5 =
-                imageRepository.save(
-                    Image(
-                        url = "url5",
-                        favorite = false,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(latePlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url5",
+                    favorite = false,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(latePlant)
+                },
+            )
             context("식물 전체 조회를 하면") {
                 val result =
                     myPlantService.findAllMyPlant(
@@ -415,27 +406,25 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     },
                 )
 
-            val image2 =
-                imageRepository.save(
-                    Image(
-                        url = "url2",
-                        favorite = true,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(recentPlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url2",
+                    favorite = true,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(recentPlant)
+                },
+            )
 
-            val image3 =
-                imageRepository.save(
-                    Image(
-                        url = "url3",
-                        favorite = false,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(recentPlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url3",
+                    favorite = false,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(recentPlant)
+                },
+            )
 
             val image4 =
                 imageRepository.save(
@@ -448,16 +437,15 @@ class MyPlantServiceIntegrationTest : DescribeSpec() {
                     },
                 )
 
-            val image5 =
-                imageRepository.save(
-                    Image(
-                        url = "url5",
-                        favorite = false,
-                        currentDate = CURRENT_DAY,
-                    ).also {
-                        it.setMyPlantRelation(latePlant)
-                    },
-                )
+            imageRepository.save(
+                Image(
+                    url = "url5",
+                    favorite = false,
+                    currentDate = CURRENT_DAY,
+                ).also {
+                    it.setMyPlantRelation(latePlant)
+                },
+            )
             context("식물 전체 조회를 하면") {
                 val result =
                     myPlantService.findAllMyPlant(

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceIntegrationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceIntegrationTest.kt
@@ -12,9 +12,11 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import java.time.LocalDate
 
 @SpringBootTest
+@ActiveProfiles("test")
 class MyPlantServiceIntegrationTest : DescribeSpec() {
     @Autowired
     lateinit var myPlantService: MyPlantService

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
@@ -43,14 +43,14 @@ class MyPlantServiceTest : DescribeSpec(
                     lastWateredDate = LAST_WATERED_DATE,
                     alarm = ALARM,
                 ).apply {
-                    id = PLANT_ID
+                    id = MYPLANT_ID
                 }
             every { locationRepository.findByIdOrNull(any()) } returns
                 LOCATION1
             context("정상 요청으로 내 식물을 저장하면") {
                 val request =
                     MyPlantSaveRequest(
-                        scientificName = SCIENTIFIC_NAME,
+                        plantId = PLANT_ID,
                         nickname = NICKNAME,
                         locationId = LOCATION_ID,
                         startDate = START_DATE,
@@ -65,7 +65,7 @@ class MyPlantServiceTest : DescribeSpec(
                 it("정상적으로 저장되고 예외가 발생하면 안된다.") {
                     val result = myPlantService.saveMyPlant(request)
 
-                    result.myPlantId shouldBe PLANT_ID
+                    result.myPlantId shouldBe MYPLANT_ID
                     result.message shouldBe "등록 되었습니다."
                 }
             }
@@ -193,7 +193,7 @@ class MyPlantServiceTest : DescribeSpec(
         }
 
         describe("내 식물 상세 조회") {
-            every { myPlantRepsitory.findByIdOrNull(PLANT_ID) } returns
+            every { myPlantRepsitory.findByIdOrNull(MYPLANT_ID) } returns
                 MyPlant(
                     scientificName = SCIENTIFIC_NAME,
                     nickname = NICKNAME,
@@ -201,7 +201,7 @@ class MyPlantServiceTest : DescribeSpec(
                     lastWateredDate = LAST_WATERED_DATE,
                     alarm = ALARM,
                 ).apply {
-                    id = PLANT_ID
+                    id = MYPLANT_ID
                 }
             every { imageRepository.findAllByMyPlant(any()) } returns
                 listOf(
@@ -225,11 +225,11 @@ class MyPlantServiceTest : DescribeSpec(
                 FERTILIZER_TITLE
             every { myPlantMessageFactory.createFertilizerInfo(any(), any()) } returns
                 FERTILIZER_INFO
-            every { myPlantRepsitory.findByIdOrNull(not(eq(PLANT_ID))) } returns
+            every { myPlantRepsitory.findByIdOrNull(not(eq(MYPLANT_ID))) } returns
                 null
             context("존재하는 ID로 상세 조회하면") {
                 it("내 식물의 상세 정보가 조회되어야 한다.") {
-                    val response = myPlantService.findMyPlantDetail(PLANT_ID, CURRENT_DAY)
+                    val response = myPlantService.findMyPlantDetail(MYPLANT_ID, CURRENT_DAY)
                     response.nickname shouldBe NICKNAME
                     response.scientificName shouldBe SCIENTIFIC_NAME
                     response.startDate shouldBe START_DATE
@@ -246,7 +246,7 @@ class MyPlantServiceTest : DescribeSpec(
                 it("NotFoundException(NOT_FOUND_MYPLANT_ID) 예외가 발생해야 한다.") {
                     val exception =
                         shouldThrow<NotFoundException> {
-                            myPlantService.findMyPlantDetail(PLANT_ID2, CURRENT_DAY)
+                            myPlantService.findMyPlantDetail(MYPLANT_ID2, CURRENT_DAY)
                         }
                     exception.message shouldBe "존재하지 않는 내 식물입니다."
                     exception.errorType shouldBe ErrorType.NOT_FOUND_MYPLANT
@@ -264,7 +264,7 @@ class MyPlantServiceTest : DescribeSpec(
                     lastFertilizerDate = LAST_FERTILIZER_DATE,
                     alarm = ALARM,
                 )
-            every { myPlantRepsitory.findByIdOrNull(not(eq(PLANT_ID))) } returns
+            every { myPlantRepsitory.findByIdOrNull(not(eq(MYPLANT_ID))) } returns
                 null
             every { locationRepository.findByName(any()) } returns
                 Location(
@@ -282,7 +282,7 @@ class MyPlantServiceTest : DescribeSpec(
                         lastFertilizerDate = LAST_FERTILIZER_DATE,
                     )
                 it("정상 흐름을 반환해야 한다.") {
-                    myPlantService.modifyMyPlant(PLANT_ID, request)
+                    myPlantService.modifyMyPlant(MYPLANT_ID, request)
                 }
             }
             context("존재하지 않는 내 식물 ID로 수정하면") {
@@ -296,7 +296,7 @@ class MyPlantServiceTest : DescribeSpec(
                     )
                 it("NotFoundException(NOT_FOUND_MYPLANT_ID) 예외가 발생해야 한다.") {
                     val exception =
-                        shouldThrow<NotFoundException> { myPlantService.modifyMyPlant(PLANT_ID2, request) }
+                        shouldThrow<NotFoundException> { myPlantService.modifyMyPlant(MYPLANT_ID2, request) }
                     exception.message shouldBe "존재하지 않는 내 식물입니다."
                     exception.errorType shouldBe ErrorType.NOT_FOUND_MYPLANT
                 }
@@ -312,7 +312,7 @@ class MyPlantServiceTest : DescribeSpec(
                     )
                 it("NotFoundException(NOT_FOUND_LOCATION_ID) 예외가 발생해야 한다.") {
                     val exception =
-                        shouldThrow<NotFoundException> { myPlantService.modifyMyPlant(PLANT_ID, request) }
+                        shouldThrow<NotFoundException> { myPlantService.modifyMyPlant(MYPLANT_ID, request) }
                     exception.message shouldBe "존재하지 않는 위치입니다."
                     exception.errorType shouldBe ErrorType.NOT_FOUND_LOCATION
                 }
@@ -320,7 +320,7 @@ class MyPlantServiceTest : DescribeSpec(
         }
 
         describe("내 식물 삭제") {
-            every { myPlantRepsitory.findByIdOrNull(PLANT_ID) } returns
+            every { myPlantRepsitory.findByIdOrNull(MYPLANT_ID) } returns
                 MyPlant(
                     scientificName = SCIENTIFIC_NAME,
                     nickname = NICKNAME,
@@ -328,22 +328,22 @@ class MyPlantServiceTest : DescribeSpec(
                     lastWateredDate = LAST_WATERED_DATE,
                     alarm = ALARM,
                 ).apply {
-                    id = PLANT_ID
+                    id = MYPLANT_ID
                 }
-            every { myPlantRepsitory.findByIdOrNull(not(eq(PLANT_ID))) } returns
+            every { myPlantRepsitory.findByIdOrNull(not(eq(MYPLANT_ID))) } returns
                 null
             every { myPlantRepsitory.delete(any()) } just runs
             every { imageRepository.deleteAllInBatchByMyPlant(any()) } just runs
 
             context("정상 요청으로 삭제하면") {
                 it("정상 흐름이 반환되어야 한다.") {
-                    myPlantService.deleteMyPlant(PLANT_ID)
+                    myPlantService.deleteMyPlant(MYPLANT_ID)
                 }
             }
             context("존재하지 않는 내 식물 ID로 삭제하면") {
                 it("NotFoundException(NOT_FOUND_MYPLANT_ID) 예외가 발생해야 한다.") {
                     val exception =
-                        shouldThrow<NotFoundException> { myPlantService.deleteMyPlant(PLANT_ID2) }
+                        shouldThrow<NotFoundException> { myPlantService.deleteMyPlant(MYPLANT_ID2) }
                     exception.message shouldBe "존재하지 않는 내 식물입니다."
                     exception.errorType shouldBe ErrorType.NOT_FOUND_MYPLANT
                 }
@@ -351,7 +351,7 @@ class MyPlantServiceTest : DescribeSpec(
         }
 
         describe("내 식물 물주기") {
-            every { myPlantRepsitory.findByIdOrNull(PLANT_ID) } returns
+            every { myPlantRepsitory.findByIdOrNull(MYPLANT_ID) } returns
                 MyPlant(
                     scientificName = SCIENTIFIC_NAME,
                     nickname = NICKNAME,
@@ -359,14 +359,14 @@ class MyPlantServiceTest : DescribeSpec(
                     lastWateredDate = LAST_WATERED_DATE,
                     alarm = ALARM,
                 ).apply {
-                    id = PLANT_ID
+                    id = MYPLANT_ID
                 }
-            every { myPlantRepsitory.findByIdOrNull(not(eq(PLANT_ID))) } returns
+            every { myPlantRepsitory.findByIdOrNull(not(eq(MYPLANT_ID))) } returns
                 null
             context("존재하는 내 식물 ID로 내 식물 물주기 요청하면") {
                 it("정상 흐름이 반환된다.") {
                     shouldNotThrowAny {
-                        myPlantService.waterMyPlant(PLANT_ID, CURRENT_DAY)
+                        myPlantService.waterMyPlant(MYPLANT_ID, CURRENT_DAY)
                     }
                 }
             }
@@ -374,7 +374,7 @@ class MyPlantServiceTest : DescribeSpec(
                 it("NotFoundException(NOT_FOUND_MYPLANT_ID) 예외가 발생해야 한다.") {
                     val exception =
                         shouldThrow<NotFoundException> {
-                            myPlantService.waterMyPlant(PLANT_ID2, CURRENT_DAY)
+                            myPlantService.waterMyPlant(MYPLANT_ID2, CURRENT_DAY)
                         }
                     exception.message shouldBe "존재하지 않는 내 식물입니다."
                     exception.errorType shouldBe ErrorType.NOT_FOUND_MYPLANT
@@ -383,7 +383,7 @@ class MyPlantServiceTest : DescribeSpec(
         }
 
         describe("내 식물 비료주기") {
-            every { myPlantRepsitory.findByIdOrNull(PLANT_ID) } returns
+            every { myPlantRepsitory.findByIdOrNull(MYPLANT_ID) } returns
                 MyPlant(
                     scientificName = SCIENTIFIC_NAME,
                     nickname = NICKNAME,
@@ -391,14 +391,14 @@ class MyPlantServiceTest : DescribeSpec(
                     lastWateredDate = LAST_WATERED_DATE,
                     alarm = ALARM,
                 ).apply {
-                    id = PLANT_ID
+                    id = MYPLANT_ID
                 }
-            every { myPlantRepsitory.findByIdOrNull(not(eq(PLANT_ID))) } returns
+            every { myPlantRepsitory.findByIdOrNull(not(eq(MYPLANT_ID))) } returns
                 null
             context("존재하는 내 식물 ID로 내 식물 비료주기 요청하면") {
                 it("정상 흐름이 반환된다.") {
                     shouldNotThrowAny {
-                        myPlantService.fertilizerMyPlant(PLANT_ID, CURRENT_DAY)
+                        myPlantService.fertilizerMyPlant(MYPLANT_ID, CURRENT_DAY)
                     }
                 }
             }
@@ -406,7 +406,7 @@ class MyPlantServiceTest : DescribeSpec(
                 it("NotFoundException(NOT_FOUND_MYPLANT_ID) 예외가 발생해야 한다.") {
                     val exception =
                         shouldThrow<NotFoundException> {
-                            myPlantService.fertilizerMyPlant(PLANT_ID2, CURRENT_DAY)
+                            myPlantService.fertilizerMyPlant(MYPLANT_ID2, CURRENT_DAY)
                         }
                     exception.message shouldBe "존재하지 않는 내 식물입니다."
                     exception.errorType shouldBe ErrorType.NOT_FOUND_MYPLANT
@@ -415,7 +415,7 @@ class MyPlantServiceTest : DescribeSpec(
         }
 
         describe("내 식물 건강확인 알림 변경") {
-            every { myPlantRepsitory.findByIdOrNull(PLANT_ID) } returns
+            every { myPlantRepsitory.findByIdOrNull(MYPLANT_ID) } returns
                 MyPlant(
                     scientificName = SCIENTIFIC_NAME,
                     nickname = NICKNAME,
@@ -423,9 +423,9 @@ class MyPlantServiceTest : DescribeSpec(
                     lastWateredDate = LAST_WATERED_DATE,
                     alarm = ALARM,
                 ).apply {
-                    id = PLANT_ID
+                    id = MYPLANT_ID
                 }
-            every { myPlantRepsitory.findByIdOrNull(not(eq(PLANT_ID))) } returns
+            every { myPlantRepsitory.findByIdOrNull(not(eq(MYPLANT_ID))) } returns
                 null
             context("존재하는 내 식물 ID로 내 식물 비료주기 요청하면") {
                 val request =
@@ -434,7 +434,7 @@ class MyPlantServiceTest : DescribeSpec(
                     )
                 it("정상 흐름이 반환된다.") {
                     shouldNotThrowAny {
-                        myPlantService.modifyMyPlantHealthCheck(PLANT_ID, request)
+                        myPlantService.modifyMyPlantHealthCheck(MYPLANT_ID, request)
                     }
                 }
             }
@@ -446,7 +446,7 @@ class MyPlantServiceTest : DescribeSpec(
                 it("NotFoundException(NOT_FOUND_MYPLANT_ID) 예외가 발생해야 한다.") {
                     val exception =
                         shouldThrow<NotFoundException> {
-                            myPlantService.modifyMyPlantHealthCheck(PLANT_ID2, request)
+                            myPlantService.modifyMyPlantHealthCheck(MYPLANT_ID2, request)
                         }
                     exception.message shouldBe "존재하지 않는 내 식물입니다."
                     exception.errorType shouldBe ErrorType.NOT_FOUND_MYPLANT
@@ -455,7 +455,7 @@ class MyPlantServiceTest : DescribeSpec(
         }
 
         describe("알림 변경") {
-            every { myPlantRepsitory.findByIdOrNull(PLANT_ID) } returns
+            every { myPlantRepsitory.findByIdOrNull(MYPLANT_ID) } returns
                 MyPlant(
                     scientificName = SCIENTIFIC_NAME,
                     nickname = NICKNAME,
@@ -463,9 +463,9 @@ class MyPlantServiceTest : DescribeSpec(
                     lastWateredDate = LAST_WATERED_DATE,
                     alarm = ALARM,
                 ).apply {
-                    id = PLANT_ID
+                    id = MYPLANT_ID
                 }
-            every { myPlantRepsitory.findByIdOrNull(not(eq(PLANT_ID))) } returns
+            every { myPlantRepsitory.findByIdOrNull(not(eq(MYPLANT_ID))) } returns
                 null
             context("존재하는 ID와 요청으로 알림 변경 요청을 하면") {
                 val request =
@@ -477,7 +477,7 @@ class MyPlantServiceTest : DescribeSpec(
                         healthCheckAlarm = HEALTHCHECK_ALARM,
                     )
                 it("알림 정보가 변경되어야 한다.") {
-                    myPlantService.modifyMyPlantAlarm(PLANT_ID, request)
+                    myPlantService.modifyMyPlantAlarm(MYPLANT_ID, request)
                 }
             }
             context("존재하지 않는 ID와 요청으로 알림 변경 요청을 하면") {
@@ -492,7 +492,7 @@ class MyPlantServiceTest : DescribeSpec(
                 it("NotFoundException(NOT_FOUND_MYPLANT_ID) 예외가 발생해야 한다.") {
                     val exception =
                         shouldThrow<NotFoundException> {
-                            myPlantService.modifyMyPlantAlarm(PLANT_ID2, request)
+                            myPlantService.modifyMyPlantAlarm(MYPLANT_ID2, request)
                         }
                     exception.message shouldBe "존재하지 않는 내 식물입니다."
                     exception.errorType shouldBe ErrorType.NOT_FOUND_MYPLANT
@@ -506,6 +506,7 @@ class MyPlantServiceTest : DescribeSpec(
         val FUTURE_DATE: LocalDate = CURRENT_DAY.plusDays(1)
 
         const val PLANT_ID = 1L
+        const val MYPLANT_ID = 1L
         const val LOCATION_ID = 100L
         const val SCIENTIFIC_NAME = "몬스테라 델리오사"
         const val NICKNAME = "뿡뿡이"
@@ -513,7 +514,7 @@ class MyPlantServiceTest : DescribeSpec(
         val START_DATE: LocalDate = CURRENT_DAY.minusDays(1)
         val LAST_WATERED_DATE: LocalDate = CURRENT_DAY.minusDays(1)
         val LAST_FERTILIZER_DATE: LocalDate = CURRENT_DAY.minusDays(1)
-        const val PLANT_ID2 = 2L
+        const val MYPLANT_ID2 = 2L
 
         const val SCIENTIFIC_NAME2 = "병아리 눈물"
         const val NICKNAME2 = "빵빵이"

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
@@ -395,7 +395,7 @@ class MyPlantServiceTest : DescribeSpec(
             context("존재하는 내 식물 ID로 내 식물 비료주기 요청하면") {
                 val request =
                     MyPlantHealthCheckRequest(
-                        healthCheck = true,
+                        _healthCheck = true,
                     )
                 it("정상 흐름이 반환된다.") {
                     shouldNotThrowAny {
@@ -406,7 +406,7 @@ class MyPlantServiceTest : DescribeSpec(
             context("존재하지 않는 내 식물 ID로 내 식물 비료주기 요청하면") {
                 val request =
                     MyPlantHealthCheckRequest(
-                        healthCheck = true,
+                        _healthCheck = true,
                     )
                 it("NotFoundException(NOT_FOUND_MYPLANT_ID) 예외가 발생해야 한다.") {
                     val exception =

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
@@ -74,7 +74,6 @@ class MyPlantServiceTest : DescribeSpec(
                 MyPlant(
                     scientificName = "병아리눈물",
                     nickname = "식물1",
-                    currentDate = LocalDate.of(2024, 5, 15),
                     lastWateredDate = LocalDate.of(2024, 5, 16),
                     lastFertilizerDate = LocalDate.of(2024, 5, 16),
                     alarm = ALARM,
@@ -86,7 +85,6 @@ class MyPlantServiceTest : DescribeSpec(
                 MyPlant(
                     scientificName = "몬스테라 델리오사",
                     nickname = "식물2",
-                    currentDate = LocalDate.of(2024, 5, 16),
                     lastWateredDate = LocalDate.of(2024, 5, 17),
                     lastFertilizerDate = LocalDate.of(2024, 5, 17),
                     alarm = ALARM,
@@ -98,7 +96,6 @@ class MyPlantServiceTest : DescribeSpec(
                 MyPlant(
                     scientificName = "선인장",
                     nickname = "식물3",
-                    currentDate = LocalDate.of(2024, 5, 17),
                     lastWateredDate = LocalDate.of(2024, 5, 15),
                     lastFertilizerDate = LocalDate.of(2024, 5, 15),
                     alarm = ALARM,
@@ -171,12 +168,10 @@ class MyPlantServiceTest : DescribeSpec(
                     Image(
                         url = "url1",
                         favorite = true,
-                        currentDate = CURRENT_DAY,
                     ),
                     Image(
                         url = "url2",
                         favorite = false,
-                        currentDate = CURRENT_DAY,
                     ),
                 )
 

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
@@ -6,7 +6,6 @@ import dnd11th.blooming.api.dto.myplant.MyPlantModifyRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantQueryCreteria
 import dnd11th.blooming.api.dto.myplant.MyPlantSaveRequest
 import dnd11th.blooming.common.exception.ErrorType
-import dnd11th.blooming.common.exception.InvalidDateException
 import dnd11th.blooming.common.exception.NotFoundException
 import dnd11th.blooming.domain.entity.Alarm
 import dnd11th.blooming.domain.entity.Image
@@ -64,82 +63,10 @@ class MyPlantServiceTest : DescribeSpec(
                         healthCheckAlarm = HEALTHCHECK_ALARM,
                     )
                 it("정상적으로 저장되고 예외가 발생하면 안된다.") {
-                    val result = myPlantService.saveMyPlant(request, CURRENT_DAY)
+                    val result = myPlantService.saveMyPlant(request)
 
                     result.myPlantId shouldBe PLANT_ID
                     result.message shouldBe "등록 되었습니다."
-                }
-            }
-            context("시작날짜가 미래인 요청으로 내 식물을 저장하면") {
-                val request =
-                    MyPlantSaveRequest(
-                        scientificName = SCIENTIFIC_NAME,
-                        nickname = NICKNAME,
-                        locationId = LOCATION_ID,
-                        startDate = FUTURE_DATE,
-                        lastWateredDate = LAST_WATERED_DATE,
-                        lastFertilizerDate = LAST_FERTILIZER_DATE,
-                        waterAlarm = WATER_ALARM,
-                        waterPeriod = WATER_PERIOD,
-                        fertilizerAlarm = FERTILIZER_ALARM,
-                        fertilizerPeriod = FERTILIZER_PERIOD,
-                        healthCheckAlarm = HEALTHCHECK_ALARM,
-                    )
-                it("InvalidDateException 예외가 발생해야 한다.") {
-                    val exception =
-                        shouldThrow<InvalidDateException> {
-                            myPlantService.saveMyPlant(request, CURRENT_DAY)
-                        }
-                    exception.message shouldBe "올바르지 않은 날짜입니다."
-                    exception.errorType shouldBe ErrorType.INVALID_DATE
-                }
-            }
-            context("마지막으로 물 준 날짜가 미래인 요청으로 내 식물을 저장하면") {
-                val request =
-                    MyPlantSaveRequest(
-                        scientificName = SCIENTIFIC_NAME,
-                        nickname = NICKNAME,
-                        locationId = LOCATION_ID,
-                        startDate = START_DATE,
-                        lastWateredDate = FUTURE_DATE,
-                        lastFertilizerDate = LAST_FERTILIZER_DATE,
-                        waterAlarm = WATER_ALARM,
-                        waterPeriod = WATER_PERIOD,
-                        fertilizerAlarm = FERTILIZER_ALARM,
-                        fertilizerPeriod = FERTILIZER_PERIOD,
-                        healthCheckAlarm = HEALTHCHECK_ALARM,
-                    )
-                it("InvalidDateException 예외가 발생해야 한다.") {
-                    val exception =
-                        shouldThrow<InvalidDateException> {
-                            myPlantService.saveMyPlant(request, CURRENT_DAY)
-                        }
-                    exception.message shouldBe "올바르지 않은 날짜입니다."
-                    exception.errorType shouldBe ErrorType.INVALID_DATE
-                }
-            }
-            context("마지막으로 비료 준 날짜가 미래인 요청으로 내 식물을 저장하면") {
-                val request =
-                    MyPlantSaveRequest(
-                        scientificName = SCIENTIFIC_NAME,
-                        nickname = NICKNAME,
-                        locationId = LOCATION_ID,
-                        startDate = START_DATE,
-                        lastWateredDate = LAST_WATERED_DATE,
-                        lastFertilizerDate = FUTURE_DATE,
-                        waterAlarm = WATER_ALARM,
-                        waterPeriod = WATER_PERIOD,
-                        fertilizerAlarm = FERTILIZER_ALARM,
-                        fertilizerPeriod = FERTILIZER_PERIOD,
-                        healthCheckAlarm = HEALTHCHECK_ALARM,
-                    )
-                it("InvalidDateException 예외가 발생해야 한다.") {
-                    val exception =
-                        shouldThrow<InvalidDateException> {
-                            myPlantService.saveMyPlant(request, CURRENT_DAY)
-                        }
-                    exception.message shouldBe "올바르지 않은 날짜입니다."
-                    exception.errorType shouldBe ErrorType.INVALID_DATE
                 }
             }
         }

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
@@ -63,7 +63,7 @@ class MyPlantServiceTest : DescribeSpec(
                         healthCheckAlarm = HEALTHCHECK_ALARM,
                     )
                 it("정상적으로 저장되고 예외가 발생하면 안된다.") {
-                    val result = myPlantService.saveMyPlant(request)
+                    val result = myPlantService.saveMyPlant(request, CURRENT_DAY)
 
                     result.myPlantId shouldBe MYPLANT_ID
                     result.message shouldBe "등록 되었습니다."

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
@@ -2,8 +2,8 @@ package dnd11th.blooming.api.service.myplant
 
 import dnd11th.blooming.api.dto.myplant.AlarmModifyRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantHealthCheckRequest
+import dnd11th.blooming.api.dto.myplant.MyPlantIdWithImageUrl
 import dnd11th.blooming.api.dto.myplant.MyPlantModifyRequest
-import dnd11th.blooming.api.dto.myplant.MyPlantQueryCreteria
 import dnd11th.blooming.api.dto.myplant.MyPlantSaveRequest
 import dnd11th.blooming.common.exception.ErrorType
 import dnd11th.blooming.common.exception.NotFoundException
@@ -75,7 +75,7 @@ class MyPlantServiceTest : DescribeSpec(
             val myPlant1 =
                 MyPlant(
                     scientificName = "병아리눈물",
-                    nickname = "생성1등 물주기2등",
+                    nickname = "식물1",
                     currentDate = LocalDate.of(2024, 5, 15),
                     lastWateredDate = LocalDate.of(2024, 5, 16),
                     lastFertilizerDate = LocalDate.of(2024, 5, 16),
@@ -87,7 +87,7 @@ class MyPlantServiceTest : DescribeSpec(
             val myPlant2 =
                 MyPlant(
                     scientificName = "몬스테라 델리오사",
-                    nickname = "생성2등 물주기3등",
+                    nickname = "식물2",
                     currentDate = LocalDate.of(2024, 5, 16),
                     lastWateredDate = LocalDate.of(2024, 5, 17),
                     lastFertilizerDate = LocalDate.of(2024, 5, 17),
@@ -99,7 +99,7 @@ class MyPlantServiceTest : DescribeSpec(
             val myPlant3 =
                 MyPlant(
                     scientificName = "선인장",
-                    nickname = "생성3등 물주기1등",
+                    nickname = "식물3",
                     currentDate = LocalDate.of(2024, 5, 17),
                     lastWateredDate = LocalDate.of(2024, 5, 15),
                     lastFertilizerDate = LocalDate.of(2024, 5, 15),
@@ -116,6 +116,12 @@ class MyPlantServiceTest : DescribeSpec(
                 listOf(myPlant3, myPlant1, myPlant2)
             every { myPlantRepsitory.findAllByLocationOrderByLastWateredDateAsc(any()) } returns
                 listOf(myPlant2, myPlant1, myPlant3)
+            every { imageRepository.findFavoriteImagesForMyPlants(any()) } returns
+                listOf(
+                    MyPlantIdWithImageUrl("url1", 1),
+                    MyPlantIdWithImageUrl("url2", 2),
+                    MyPlantIdWithImageUrl("url3", 3),
+                )
             every { locationRepository.findByIdOrNull(any()) } returns
                 null
             every { locationRepository.findByIdOrNull(LOCATION_ID) } returns
@@ -128,66 +134,25 @@ class MyPlantServiceTest : DescribeSpec(
                     response.size shouldBe 3
 
                     response[0].myPlantId shouldBe 1
-                    response[0].nickname shouldBe "생성1등 물주기2등"
+                    response[0].nickname shouldBe "식물1"
+                    response[0].imageUrl shouldBe "url1"
                     response[0].scientificName shouldBe "병아리눈물"
                     response[0].waterRemainDay shouldBe 2
                     response[0].fertilizerRemainDay shouldBe 29
 
                     response[1].myPlantId shouldBe 2
-                    response[1].nickname shouldBe "생성2등 물주기3등"
+                    response[1].nickname shouldBe "식물2"
+                    response[1].imageUrl shouldBe "url2"
                     response[1].scientificName shouldBe "몬스테라 델리오사"
                     response[1].waterRemainDay shouldBe 3
                     response[1].fertilizerRemainDay shouldBe 30
 
                     response[2].myPlantId shouldBe 3
-                    response[2].nickname shouldBe "생성3등 물주기1등"
+                    response[2].nickname shouldBe "식물3"
+                    response[2].imageUrl shouldBe "url3"
                     response[2].scientificName shouldBe "선인장"
                     response[2].waterRemainDay shouldBe 1
                     response[2].fertilizerRemainDay shouldBe 28
-                }
-            }
-            context("내 식물을 최근 등록순으로 전체 조회하면") {
-                it("순서에 맞게 내 식물 리스트가 조회되어야 한다.") {
-                    val response = myPlantService.findAllMyPlant(CURRENT_DAY, null, MyPlantQueryCreteria.CreatedDesc)
-                    response.size shouldBe 3
-                    response[0].nickname shouldBe "생성1등 물주기2등"
-                    response[1].nickname shouldBe "생성2등 물주기3등"
-                    response[2].nickname shouldBe "생성3등 물주기1등"
-                }
-            }
-            context("내 식물을 오래된 등록순으로 전체 조회하면") {
-                it("순서에 맞게 내 식물 리스트가 조회되어야 한다.") {
-                    val response = myPlantService.findAllMyPlant(CURRENT_DAY, null, MyPlantQueryCreteria.CreatedAsc)
-                    response.size shouldBe 3
-                    response[0].nickname shouldBe "생성3등 물주기1등"
-                    response[1].nickname shouldBe "생성2등 물주기3등"
-                    response[2].nickname shouldBe "생성1등 물주기2등"
-                }
-            }
-            context("내 식물을 최근 물 준 순으로 전체 조회하면") {
-                it("순서에 맞게 내 식물 리스트가 조회되어야 한다.") {
-                    val response = myPlantService.findAllMyPlant(CURRENT_DAY, null, MyPlantQueryCreteria.WateredDesc)
-                    response.size shouldBe 3
-                    response[0].nickname shouldBe "생성3등 물주기1등"
-                    response[1].nickname shouldBe "생성1등 물주기2등"
-                    response[2].nickname shouldBe "생성2등 물주기3등"
-                }
-            }
-            context("내 식물을 오래된 물 준 순으로 전체 조회하면") {
-                it("순서에 맞게 내 식물 리스트가 조회되어야 한다.") {
-                    val response = myPlantService.findAllMyPlant(CURRENT_DAY, null, MyPlantQueryCreteria.WateredAsc)
-                    response.size shouldBe 3
-                    response[0].nickname shouldBe "생성2등 물주기3등"
-                    response[1].nickname shouldBe "생성1등 물주기2등"
-                    response[2].nickname shouldBe "생성3등 물주기1등"
-                }
-            }
-            context("내 식물을 locationId를 포함하여 전체 조회하면") {
-                it("해당 location의 식물만이 조회된다.") {
-                    val response = myPlantService.findAllMyPlant(CURRENT_DAY, LOCATION_ID)
-                    response.size shouldBe 2
-                    response[0].nickname shouldBe "생성1등 물주기2등"
-                    response[1].nickname shouldBe "생성2등 물주기3등"
                 }
             }
         }

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
@@ -1,10 +1,10 @@
 package dnd11th.blooming.api.service.myplant
 
 import dnd11th.blooming.api.dto.myplant.AlarmModifyRequest
+import dnd11th.blooming.api.dto.myplant.MyPlantCreateDto
 import dnd11th.blooming.api.dto.myplant.MyPlantHealthCheckRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantIdWithImageUrl
 import dnd11th.blooming.api.dto.myplant.MyPlantModifyRequest
-import dnd11th.blooming.api.dto.myplant.MyPlantSaveRequest
 import dnd11th.blooming.common.exception.ErrorType
 import dnd11th.blooming.common.exception.NotFoundException
 import dnd11th.blooming.domain.entity.Alarm
@@ -49,10 +49,8 @@ class MyPlantServiceTest : DescribeSpec(
                 LOCATION1
             context("정상 요청으로 내 식물을 저장하면") {
                 val request =
-                    MyPlantSaveRequest(
-                        plantId = PLANT_ID,
+                    MyPlantCreateDto(
                         nickname = NICKNAME,
-                        locationId = LOCATION_ID,
                         startDate = START_DATE,
                         lastWateredDate = LAST_WATERED_DATE,
                         lastFertilizerDate = LAST_FERTILIZER_DATE,
@@ -63,7 +61,7 @@ class MyPlantServiceTest : DescribeSpec(
                         healthCheckAlarm = HEALTHCHECK_ALARM,
                     )
                 it("정상적으로 저장되고 예외가 발생하면 안된다.") {
-                    val result = myPlantService.saveMyPlant(request, CURRENT_DAY)
+                    val result = myPlantService.saveMyPlant(request, LOCATION_ID, CURRENT_DAY)
 
                     result.myPlantId shouldBe MYPLANT_ID
                     result.message shouldBe "등록 되었습니다."

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
@@ -395,7 +395,7 @@ class MyPlantServiceTest : DescribeSpec(
             context("존재하는 내 식물 ID로 내 식물 비료주기 요청하면") {
                 val request =
                     MyPlantHealthCheckRequest(
-                        _healthCheck = true,
+                        healthCheck = true,
                     )
                 it("정상 흐름이 반환된다.") {
                     shouldNotThrowAny {
@@ -406,7 +406,7 @@ class MyPlantServiceTest : DescribeSpec(
             context("존재하지 않는 내 식물 ID로 내 식물 비료주기 요청하면") {
                 val request =
                     MyPlantHealthCheckRequest(
-                        _healthCheck = true,
+                        healthCheck = true,
                     )
                 it("NotFoundException(NOT_FOUND_MYPLANT_ID) 예외가 발생해야 한다.") {
                     val exception =

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
@@ -61,7 +61,7 @@ class MyPlantServiceTest : DescribeSpec(
                         healthCheckAlarm = HEALTHCHECK_ALARM,
                     )
                 it("정상적으로 저장되고 예외가 발생하면 안된다.") {
-                    val result = myPlantService.saveMyPlant(request, LOCATION_ID, CURRENT_DAY)
+                    val result = myPlantService.saveMyPlant(request, LOCATION_ID)
 
                     result.myPlantId shouldBe MYPLANT_ID
                     result.message shouldBe "등록 되었습니다."


### PR DESCRIPTION
> ### How
- spring validation을 추가하였습니다.
- validation 실패시 발생하는 예외에 대하여 전역 예외처리를 추가하였습니다.
- validation이 실제 잘 동작하는지 확인하기 위한 테스트를 작성하였습니다.
- api가 명세서와 다른 부분이 몇개 발견되어, 수정하였습니다.
- 도메인 엔티티 생성/연관관계 매핑 코드를 requestDto가 아니라, 도메인 엔티티 자체에서 수행하도록 리팩토링했습니다.

> ### Result
- validation
  - 이제 요청으로 들어오는 request를 검증할 수 있게 되었습니다.
- api
  - 식물 저장 api의 요청에서 scientificName 대신에 plantId를 받습니다.
  - 식물 전체 조회 api의 응답에서 이제 각 식물의 대표 이미지를 볼 수 있습니다.
  - 식물 전체 조회 api의 경우 계층끼리 잘 작동하는지 확인하기 위해 따로 통합테스트를 진행하였습니다.
  - 수정된 api들도 swagger 문서화  적용하였습니다.
