### PR TITLE
[BLOOM-057] WebMvc 환경 통합 및 Test 환경 구성

### DIFF
--- a/src/test/kotlin/dnd11th/blooming/api/controller/home/HomeControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/home/HomeControllerTest.kt
@@ -1,35 +1,13 @@
 package dnd11th.blooming.api.controller.home
 
-import com.ninjasquad.springmockk.MockkBean
 import dnd11th.blooming.api.dto.home.HomeResponse
 import dnd11th.blooming.api.dto.home.MyPlantHomeResponse
-import dnd11th.blooming.api.service.home.HomeService
-import dnd11th.blooming.common.jwt.JwtProvider
-import dnd11th.blooming.domain.repository.user.UserRepository
-import io.kotest.core.spec.style.DescribeSpec
+import dnd11th.blooming.support.WebMvcDescribeSpec
 import io.mockk.every
 import org.hamcrest.CoreMatchers.equalTo
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 
-@WebMvcTest(HomeController::class)
-@ActiveProfiles("test")
-class HomeControllerTest : DescribeSpec() {
-    @MockkBean
-    private lateinit var homeService: HomeService
-
-    @MockkBean
-    private lateinit var jwtProvider: JwtProvider
-
-    @MockkBean
-    private lateinit var userRepository: UserRepository
-
-    @Autowired
-    private lateinit var mockMvc: MockMvc
-
+class HomeControllerTest : WebMvcDescribeSpec() {
     init {
         describe("홈 화면") {
             every { homeService.getHome(any()) } returns

--- a/src/test/kotlin/dnd11th/blooming/api/controller/image/ImageControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/image/ImageControllerValidationTest.kt
@@ -1,41 +1,15 @@
 package dnd11th.blooming.api.controller.image
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.ninjasquad.springmockk.MockkBean
 import dnd11th.blooming.api.dto.image.ImageFavoriteModifyRequest
 import dnd11th.blooming.api.dto.image.ImageSaveRequest
-import dnd11th.blooming.api.service.image.ImageService
 import dnd11th.blooming.common.exception.ErrorType
-import dnd11th.blooming.common.jwt.JwtProvider
-import dnd11th.blooming.domain.repository.user.UserRepository
-import io.kotest.core.spec.style.DescribeSpec
+import dnd11th.blooming.support.WebMvcDescribeSpec
 import org.hamcrest.CoreMatchers.equalTo
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
 
-@WebMvcTest(ImageController::class)
-@ActiveProfiles("test")
-class ImageControllerValidationTest : DescribeSpec() {
-    @MockkBean
-    private lateinit var imageService: ImageService
-
-    @MockkBean
-    private lateinit var jwtProvider: JwtProvider
-
-    @MockkBean
-    private lateinit var userRepository: UserRepository
-
-    @Autowired
-    private lateinit var mockMvc: MockMvc
-
-    @Autowired
-    private lateinit var objectMapper: ObjectMapper
-
+class ImageControllerValidationTest : WebMvcDescribeSpec() {
     init {
         describe("이미지 저장") {
             context("이미지URL을 전달하지 않으면") {

--- a/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerTest.kt
@@ -1,49 +1,23 @@
 package dnd11th.blooming.api.controller.location
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.ninjasquad.springmockk.MockkBean
 import dnd11th.blooming.api.dto.location.LocationModifyRequest
 import dnd11th.blooming.api.dto.location.LocationResponse
 import dnd11th.blooming.api.dto.location.LocationSaveRequest
 import dnd11th.blooming.api.dto.location.LocationSaveResponse
-import dnd11th.blooming.api.service.location.LocationService
 import dnd11th.blooming.common.exception.ErrorType
 import dnd11th.blooming.common.exception.NotFoundException
-import dnd11th.blooming.common.jwt.JwtProvider
-import dnd11th.blooming.domain.repository.user.UserRepository
-import io.kotest.core.spec.style.DescribeSpec
+import dnd11th.blooming.support.WebMvcDescribeSpec
 import io.mockk.every
 import io.mockk.just
 import io.mockk.runs
 import org.hamcrest.CoreMatchers.equalTo
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
 
-@WebMvcTest(LocationController::class)
-@ActiveProfiles("test")
-class LocationControllerTest : DescribeSpec() {
-    @MockkBean
-    private lateinit var locationService: LocationService
-
-    @MockkBean
-    private lateinit var jwtProvider: JwtProvider
-
-    @MockkBean
-    private lateinit var userRepository: UserRepository
-
-    @Autowired
-    private lateinit var mockMvc: MockMvc
-
-    @Autowired
-    private lateinit var objectMapper: ObjectMapper
-
+class LocationControllerTest : WebMvcDescribeSpec() {
     init {
         describe("위치 저장") {
             every { locationService.saveLocation(any()) } returns

--- a/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/location/LocationControllerValidationTest.kt
@@ -1,41 +1,15 @@
 package dnd11th.blooming.api.controller.location
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.ninjasquad.springmockk.MockkBean
 import dnd11th.blooming.api.dto.location.LocationModifyRequest
 import dnd11th.blooming.api.dto.location.LocationSaveRequest
-import dnd11th.blooming.api.service.location.LocationService
 import dnd11th.blooming.common.exception.ErrorType
-import dnd11th.blooming.common.jwt.JwtProvider
-import dnd11th.blooming.domain.repository.user.UserRepository
-import io.kotest.core.spec.style.DescribeSpec
+import dnd11th.blooming.support.WebMvcDescribeSpec
 import org.hamcrest.CoreMatchers.equalTo
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
 
-@WebMvcTest(LocationController::class)
-@ActiveProfiles("test")
-class LocationControllerValidationTest : DescribeSpec() {
-    @MockkBean
-    private lateinit var locationService: LocationService
-
-    @MockkBean
-    private lateinit var jwtProvider: JwtProvider
-
-    @MockkBean
-    private lateinit var userRepository: UserRepository
-
-    @Autowired
-    private lateinit var mockMvc: MockMvc
-
-    @Autowired
-    private lateinit var objectMapper: ObjectMapper
-
+class LocationControllerValidationTest : WebMvcDescribeSpec() {
     init {
         describe("위치 저장") {
             context("위치명을 전달하지 않으면") {

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
@@ -1,7 +1,5 @@
 package dnd11th.blooming.api.controller.myplant
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.ninjasquad.springmockk.MockkBean
 import dnd11th.blooming.api.dto.image.ImageResponse
 import dnd11th.blooming.api.dto.myplant.AlarmModifyRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantDetailResponse
@@ -10,45 +8,21 @@ import dnd11th.blooming.api.dto.myplant.MyPlantModifyRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantResponse
 import dnd11th.blooming.api.dto.myplant.MyPlantSaveRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantSaveResponse
-import dnd11th.blooming.api.service.myplant.MyPlantService
 import dnd11th.blooming.common.exception.ErrorType
 import dnd11th.blooming.common.exception.NotFoundException
-import dnd11th.blooming.common.jwt.JwtProvider
-import dnd11th.blooming.domain.repository.user.UserRepository
-import io.kotest.core.spec.style.DescribeSpec
+import dnd11th.blooming.support.WebMvcDescribeSpec
 import io.mockk.every
 import io.mockk.just
 import io.mockk.runs
 import org.hamcrest.CoreMatchers.equalTo
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
 import java.time.LocalDate
 
-@WebMvcTest(MyPlantController::class)
-@ActiveProfiles("test")
-class MyPlantControllerTest : DescribeSpec() {
-    @MockkBean
-    private lateinit var myPlantService: MyPlantService
-
-    @MockkBean
-    private lateinit var jwtProvider: JwtProvider
-
-    @MockkBean
-    private lateinit var userRepository: UserRepository
-
-    @Autowired
-    private lateinit var mockMvc: MockMvc
-
-    @Autowired
-    private lateinit var objectMapper: ObjectMapper
-
+class MyPlantControllerTest : WebMvcDescribeSpec() {
     init {
         describe("내 식물 저장") {
             beforeTest {

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerValidationTest.kt
@@ -1,44 +1,18 @@
 package dnd11th.blooming.api.controller.myplant
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.ninjasquad.springmockk.MockkBean
 import dnd11th.blooming.api.dto.myplant.AlarmModifyRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantHealthCheckRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantModifyRequest
 import dnd11th.blooming.api.dto.myplant.MyPlantSaveRequest
-import dnd11th.blooming.api.service.myplant.MyPlantService
 import dnd11th.blooming.common.exception.ErrorType
-import dnd11th.blooming.common.jwt.JwtProvider
-import dnd11th.blooming.domain.repository.user.UserRepository
-import io.kotest.core.spec.style.DescribeSpec
+import dnd11th.blooming.support.WebMvcDescribeSpec
 import org.hamcrest.CoreMatchers.equalTo
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
 import java.time.LocalDate
 
-@WebMvcTest(MyPlantController::class)
-@ActiveProfiles("test")
-class MyPlantControllerValidationTest : DescribeSpec() {
-    @MockkBean
-    private lateinit var myPlantService: MyPlantService
-
-    @MockkBean
-    private lateinit var jwtProvider: JwtProvider
-
-    @MockkBean
-    private lateinit var userRepository: UserRepository
-
-    @Autowired
-    private lateinit var mockMvc: MockMvc
-
-    @Autowired
-    private lateinit var objectMapper: ObjectMapper
-
+class MyPlantControllerValidationTest : WebMvcDescribeSpec() {
     init {
         describe("내 식물 저장") {
             context("식물종류를 전달하지 않으면") {

--- a/src/test/kotlin/dnd11th/blooming/support/StubAuthInterceptor.kt
+++ b/src/test/kotlin/dnd11th/blooming/support/StubAuthInterceptor.kt
@@ -1,0 +1,15 @@
+package dnd11th.blooming.support
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.web.servlet.HandlerInterceptor
+
+class StubAuthInterceptor : HandlerInterceptor {
+    override fun preHandle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+    ): Boolean {
+        return true
+    }
+}

--- a/src/test/kotlin/dnd11th/blooming/support/StubHandlerArgumentResolver.kt
+++ b/src/test/kotlin/dnd11th/blooming/support/StubHandlerArgumentResolver.kt
@@ -1,0 +1,24 @@
+package dnd11th.blooming.support
+
+import dnd11th.blooming.domain.entity.user.AlarmTime
+import dnd11th.blooming.domain.entity.user.User
+import org.springframework.core.MethodParameter
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+class StubHandlerArgumentResolver : HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return true
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?,
+    ): User {
+        return User("test@naver.com", "testuser", AlarmTime.TIME_10_11, 55, 127, 1L)
+    }
+}

--- a/src/test/kotlin/dnd11th/blooming/support/TestWebMvcConfig.kt
+++ b/src/test/kotlin/dnd11th/blooming/support/TestWebMvcConfig.kt
@@ -1,0 +1,17 @@
+package dnd11th.blooming.support
+
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@TestConfiguration
+class TestWebMvcConfig : WebMvcConfigurer {
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(StubHandlerArgumentResolver())
+    }
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(StubAuthInterceptor())
+    }
+}

--- a/src/test/kotlin/dnd11th/blooming/support/WebMvcDescribeSpec.kt
+++ b/src/test/kotlin/dnd11th/blooming/support/WebMvcDescribeSpec.kt
@@ -1,0 +1,77 @@
+package dnd11th.blooming.support
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import dnd11th.blooming.api.config.WebMvcConfig
+import dnd11th.blooming.api.controller.home.HomeController
+import dnd11th.blooming.api.controller.image.ImageController
+import dnd11th.blooming.api.controller.location.LocationController
+import dnd11th.blooming.api.controller.myplant.MyPlantController
+import dnd11th.blooming.api.service.home.HomeService
+import dnd11th.blooming.api.service.image.ImageService
+import dnd11th.blooming.api.service.location.LocationService
+import dnd11th.blooming.api.service.myplant.MyPlantService
+import dnd11th.blooming.common.interceptor.AuthInterceptor
+import dnd11th.blooming.common.resolver.LoginUserArgumentResolver
+import dnd11th.blooming.common.resolver.PendingUserArgumentResolver
+import io.kotest.core.spec.style.DescribeSpec
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+
+@WebMvcTest(
+    value = [
+        HomeController::class,
+        LocationController::class,
+        MyPlantController::class,
+        ImageController::class,
+    ],
+    excludeFilters = [
+        ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = [
+                WebMvcConfig::class, AuthInterceptor::class,
+                LoginUserArgumentResolver::class, PendingUserArgumentResolver::class,
+            ],
+        ),
+    ],
+)
+@Import(TestWebMvcConfig::class)
+@ActiveProfiles("test")
+abstract class WebMvcDescribeSpec : DescribeSpec() {
+    @Autowired
+    protected lateinit var context: WebApplicationContext
+
+    @Autowired
+    protected lateinit var mockMvc: MockMvc
+
+    @Autowired
+    protected lateinit var objectMapper: ObjectMapper
+
+    @MockkBean
+    protected lateinit var homeService: HomeService
+
+    @MockkBean
+    protected lateinit var imageService: ImageService
+
+    @MockkBean
+    protected lateinit var myPlantService: MyPlantService
+
+    @MockkBean
+    protected lateinit var locationService: LocationService
+
+    @BeforeEach
+    fun setUp() {
+        mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(context)
+                .build()
+    }
+}


### PR DESCRIPTION
<!-- 제목은 아래처럼 -->
<!-- [BLOOM-001] PR 제목 -->
Close #57 
> ### How
<!-- 해당 테스크를 수행하기 위한 과정과 흐름에 대해 집중해서 작성해주세요. -->
- StubInterceptor, StubArgumentResolver를 통해 Test용 WebMvcTest환경을 구성했습니다.
- 기존 WebMvcTest에 WebMvcConfig 및 Interceptor, ArgumentResolver를 제외시키고 새로운 환경으로 대체하였습니다.
- WebMvc 환경의 여러번 띄워지고 중복되는 빈들을 하나로 모았습니다.
> ### Result
<!-- 해당 테스크를 통한 결과에 대해 짧게 작성해주세요. -->
<!-- 작업한 내용, 스크린샷 -->
- 테스트 시간 단축
- 테스트용 환경 구성, Inteceptor와 ArgumentResolver를 mocking할 필요 제거

