### PR TITLE
[BLOOM-077] 식물 Enum명 수정

### DIFF
--- a/src/main/kotlin/dnd11th/blooming/api/service/guide/provider/LightDetailProvider.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/guide/provider/LightDetailProvider.kt
@@ -32,7 +32,7 @@ class LightDetailProvider {
         val description =
             when (plant.light) {
                 Light.LOW, Light.LOW_MEDIUM, Light.LOW_MEDIUM_HIGH -> "빛을 많이 받지 않아도 괜찮습니다."
-                Light.MEDIUM, Light.MEDIUMT_HIGH -> "간접적인 밝은 빛을 가장 좋아합니다.\n단, 직사광선은 잎을 태울 수 있으므로 피하는 것이 좋아요."
+                Light.MEDIUM, Light.MEDIUM_HIGH -> "간접적인 밝은 빛을 가장 좋아합니다.\n단, 직사광선은 잎을 태울 수 있으므로 피하는 것이 좋아요."
                 Light.HIGH -> "직접적인 밝은 빛을 가장 좋아합니다."
             }
 

--- a/src/main/kotlin/dnd11th/blooming/api/service/guide/provider/StaticPlantSimpleMessageProvider.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/guide/provider/StaticPlantSimpleMessageProvider.kt
@@ -137,8 +137,8 @@ class StaticPlantSimpleMessageProvider {
 
     private fun makeSimpleFertilizerDescription(plant: Plant): String {
         return when (plant.fertilizer) {
-            Fertilizer.DEMANDING -> "봄, 여름에 2~4주 간격으로 주기"
-            Fertilizer.NOT_VERY_DEMANDING -> "봄, 여름에 4~8주 간격으로 주기"
+            Fertilizer.DEMAND -> "봄, 여름에 2~4주 간격으로 주기"
+            Fertilizer.LOW_DEMAND -> "봄, 여름에 4~8주 간격으로 주기"
         }
     }
 }

--- a/src/main/kotlin/dnd11th/blooming/api/service/guide/provider/StaticPlantSimpleMessageProvider.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/guide/provider/StaticPlantSimpleMessageProvider.kt
@@ -129,7 +129,7 @@ class StaticPlantSimpleMessageProvider {
     private fun makeSimpleTemperatureDescription(plant: Plant): String {
         val growTemperatureDescription =
             "${plant.growTemperature.lowTemperature}" +
-                "~${plant.growTemperature.hightTemperature}사이"
+                "~${plant.growTemperature.highTemperature}사이"
         val lowestTemperature = "${plant.lowestTemperature.temperature}도 이하는 주의할 것"
 
         return "${growTemperatureDescription}\n$lowestTemperature"

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/plant/Fertilizer.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/plant/Fertilizer.kt
@@ -4,11 +4,11 @@ enum class Fertilizer(
     val periodWeek: Int,
     val apiName: String,
 ) {
-    NOT_VERY_DEMANDING(
+    LOW_DEMAND(
         8,
         "비료를 거의 요구하지 않음",
     ),
-    DEMANDING(
+    DEMAND(
         4,
         "비료를 보통 요구함",
     ),

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/plant/GrowTemperature.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/plant/GrowTemperature.kt
@@ -2,14 +2,14 @@ package dnd11th.blooming.domain.entity.plant
 
 enum class GrowTemperature(
     val lowTemperature: Int,
-    val hightTemperature: Int,
+    val highTemperature: Int,
 ) {
     GROW_TEMPERATURE_16_20(
         16,
         20,
     ),
     GROW_TEMPERATURE_21_25(
-        16,
-        20,
+        21,
+        25,
     ),
 }

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/plant/Light.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/plant/Light.kt
@@ -15,7 +15,7 @@ enum class Light(
     LOW_MEDIUM(
         "낮은 광도(300~800Lux), 중간 광도(800~1,500Lux)",
     ),
-    MEDIUMT_HIGH(
+    MEDIUM_HIGH(
         "중간 광도(800~1,500Lux), 높은 광도(1,500~10,000Lux)",
     ),
     LOW_MEDIUM_HIGH(

--- a/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/myplant/MyPlantServiceTest.kt
@@ -562,7 +562,7 @@ class MyPlantServiceTest : DescribeSpec(
                 GrowTemperature.GROW_TEMPERATURE_16_20,
                 LowestTemperature.LOWEST_TEMPERATURE_13,
                 Toxicity.EXISTS,
-                Fertilizer.NOT_VERY_DEMANDING,
+                Fertilizer.LOW_DEMAND,
                 Humidity.HUMIDITY_0_40,
                 "",
                 GrowLocation.VERANDA,


### PR DESCRIPTION
> ### How
- 식물의 Enum 명들에 있는 오타를 수정하고 가독성을 좋게 했습니다.

> ### Result
- Light 오타수정
- GrowTemperature 오타수정
- Fertilizer 가독성 향상
