### PR TITLE
[BLOOM-087] 식물 상세 조회 api 응답필드 추가

### DIFF
--- a/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantDetailResponse.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/dto/myplant/MyPlantDetailResponse.kt
@@ -1,6 +1,7 @@
 package dnd11th.blooming.api.dto.myplant
 
 import dnd11th.blooming.api.dto.image.ImageResponse
+import dnd11th.blooming.api.dto.location.LocationResponse
 import dnd11th.blooming.api.service.myplant.MyPlantMessageFactory
 import dnd11th.blooming.domain.entity.Image
 import dnd11th.blooming.domain.entity.MyPlant
@@ -19,8 +20,8 @@ data class MyPlantDetailResponse(
     val scientificName: String,
     @field:Schema(description = "식물 ID", example = "7")
     val plantId: Long?,
-    @field:Schema(description = "내 식물 위치 이름", example = "베란다")
-    val location: String?,
+    @field:Schema(description = "내 식물 위치")
+    val location: LocationResponse?,
     @field:Schema(description = "함께한지 N일째", example = "13")
     val withDays: Int,
     @field:Schema(description = "마지막으로 물 준 날짜 컴포넌트 제목", example = "마지막으로 물 준 날")
@@ -59,7 +60,7 @@ data class MyPlantDetailResponse(
                 nickname = myPlant.nickname,
                 scientificName = myPlant.scientificName,
                 plantId = myPlant.plant?.id,
-                location = myPlant.getLocationName(),
+                location = myPlant.location?.let { LocationResponse.from(it) },
                 withDays = Period.between(myPlant.startDate, now).days,
                 lastWateredTitle = messageFactory.createWateredTitle(),
                 lastWateredInfo = messageFactory.createWateredInfo(myPlant.lastWateredDate, now),

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/MyPlant.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/MyPlant.kt
@@ -52,10 +52,6 @@ class MyPlant(
     @JoinColumn(name = "location_id")
     var location: Location? = null
 
-    fun getLocationName(): String? {
-        return location?.name
-    }
-
     fun getDateSinceLastWater(now: LocalDate): Int? {
         return lastWateredDate?.let { Period.between(lastWateredDate, now).days }
     }

--- a/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantControllerTest.kt
@@ -1,6 +1,7 @@
 package dnd11th.blooming.api.controller.myplant
 
 import dnd11th.blooming.api.dto.image.ImageResponse
+import dnd11th.blooming.api.dto.location.LocationResponse
 import dnd11th.blooming.api.dto.myplant.AlarmModifyRequest
 import dnd11th.blooming.api.dto.myplant.HealthCheckResponse
 import dnd11th.blooming.api.dto.myplant.MyPlantDetailResponse
@@ -151,7 +152,7 @@ class MyPlantControllerTest : WebMvcDescribeSpec() {
                         nickname = NICKNAME,
                         scientificName = SCIENTIFIC_NAME,
                         plantId = PLANT_ID,
-                        location = LOCATION_NAME,
+                        location = LocationResponse(LOCATION_ID, LOCATION_NAME),
                         withDays = WITH_DAYS,
                         lastWateredTitle = LAST_WATERED_TITLE,
                         lastWateredInfo = LAST_WATERED_INFO,
@@ -190,7 +191,8 @@ class MyPlantControllerTest : WebMvcDescribeSpec() {
                             status { isOk() }
                             jsonPath("$.nickname", equalTo(NICKNAME))
                             jsonPath("$.scientificName", equalTo(SCIENTIFIC_NAME))
-                            jsonPath("$.location", equalTo(LOCATION_NAME))
+                            jsonPath("$.location.id", equalTo(LOCATION_ID.toInt()))
+                            jsonPath("$.location.name", equalTo(LOCATION_NAME))
                             jsonPath("$.withDays", equalTo(WITH_DAYS))
                             jsonPath("$.lastWateredTitle", equalTo(LAST_WATERED_TITLE))
                             jsonPath("$.lastWateredInfo", equalTo(LAST_WATERED_INFO))


### PR DESCRIPTION
> ### How
- MyPlantDetailResponse 객체의 location 필드를 String? 에서 LocationResponse? 타입으로 수정하였습니다.
- MyPlantDetailResponse 객체의 정적 팩토리 메서드를 수정하였습니다.
- 테스트 오류를 수정했습니다.

> ### Result
- 이제 식물 상세 조회 api 에서 위치 id 값도 받아볼 수 있습니다.
