### PR TITLE
[BLOOM-089] 위치등록시 위치명 중복 예외 추가

### DIFF
--- a/src/main/kotlin/dnd11th/blooming/api/controller/location/LocationApi.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/location/LocationApi.kt
@@ -19,7 +19,13 @@ import io.swagger.v3.oas.annotations.tags.Tag
 interface LocationApi {
     @Operation(summary = "위치를 저장하는 API 입니다.")
     @ApiResponse(responseCode = "200", description = "위치 저장 성공")
-    @ApiErrorResponse(errorType = ErrorType.BAD_REQUEST, description = "요청의 name이 null이거나 비어있을 때 에러입니다.")
+    @ApiErrorResponses(
+        [
+            ApiErrorResponse(ErrorType.BAD_REQUEST, "요청의 name이 null이거나 비어있을 때 에러입니다."),
+            ApiErrorResponse(ErrorType.LOCATION_COUNT_EXCEED, "위치의 개수가 3개가 넘었을 때 에러입니다."),
+            ApiErrorResponse(ErrorType.LOCATION_NAME_DUPLICATE, "위치의 이름이 중복되었을 때 에러입니다."),
+        ],
+    )
     fun saveLocation(
         @RequestBody(description = "위치 저장 요청", required = true)
         request: LocationSaveRequest,

--- a/src/main/kotlin/dnd11th/blooming/api/service/location/LocationService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/location/LocationService.kt
@@ -24,10 +24,14 @@ class LocationService(
         dto: LocationCreateDto,
         user: User,
     ): LocationSaveResponse {
-        if (locationRepository.countByUser(user) >= MAX_LOCATION_LIMIT) {
-            throw BadRequestException(
-                ErrorType.LOCATION_COUNT_EXCEED,
-            )
+        val locations = locationRepository.findAllByUser(user)
+
+        if (locations.size >= MAX_LOCATION_LIMIT) throw BadRequestException(ErrorType.LOCATION_COUNT_EXCEED)
+        if (locations.any { location ->
+                location.name == dto.name
+            }
+        ) {
+            throw BadRequestException(ErrorType.LOCATION_NAME_DUPLICATE)
         }
 
         val location = Location.createLocation(dto, user)

--- a/src/main/kotlin/dnd11th/blooming/api/service/location/LocationService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/location/LocationService.kt
@@ -26,13 +26,8 @@ class LocationService(
     ): LocationSaveResponse {
         val locations = locationRepository.findAllByUser(user)
 
-        if (locations.size >= MAX_LOCATION_LIMIT) throw BadRequestException(ErrorType.LOCATION_COUNT_EXCEED)
-        if (locations.any { location ->
-                location.name == dto.name
-            }
-        ) {
-            throw BadRequestException(ErrorType.LOCATION_NAME_DUPLICATE)
-        }
+        validateLocationSizeNotExceed(locations.size)
+        validateLocationNameUnique(locations, dto.name)
 
         val location = Location.createLocation(dto, user)
 
@@ -78,6 +73,22 @@ class LocationService(
     }
 
     companion object {
-        const val MAX_LOCATION_LIMIT = 3
+        private const val MAX_LOCATION_LIMIT = 3
+    }
+
+    private fun validateLocationNameUnique(
+        locations: List<Location>,
+        newLocationName: String,
+    ) {
+        if (locations.any { location ->
+                location.name == newLocationName
+            }
+        ) {
+            throw BadRequestException(ErrorType.LOCATION_NAME_DUPLICATE)
+        }
+    }
+
+    private fun validateLocationSizeNotExceed(locationsSize: Int) {
+        if (locationsSize >= MAX_LOCATION_LIMIT) throw BadRequestException(ErrorType.LOCATION_COUNT_EXCEED)
     }
 }

--- a/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
@@ -19,6 +19,7 @@ enum class ErrorType(val status: HttpStatus, var message: String, val logLevel: 
 
     // Location
     NOT_FOUND_LOCATION(HttpStatus.NOT_FOUND, "존재하지 않는 위치입니다.", LogLevel.DEBUG),
+    LOCATION_NAME_DUPLICATE(HttpStatus.NOT_FOUND, "이미 존재하는 위치명입니다.", LogLevel.DEBUG),
     LOCATION_COUNT_EXCEED(HttpStatus.BAD_REQUEST, "위치는 최대 3개까지만 등록 가능합니다.", LogLevel.DEBUG),
 
     // Auth

--- a/src/main/kotlin/dnd11th/blooming/domain/repository/LocationRepository.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/repository/LocationRepository.kt
@@ -11,6 +11,4 @@ interface LocationRepository : JpaRepository<Location, Long> {
         id: Long,
         user: User,
     ): Location?
-
-    fun countByUser(user: User): Int
 }


### PR DESCRIPTION
> ### How
- ErrorType을 정의하고, LocationService에서 조건을 체크한 후 예외를 터트리도록 했습니다.

> ### Result
- 이제 중복된 Location명에 대해 체크할 수 있게 되었습니다.
