### PR TITLE
[BLOOM-098] 식물 종류 검색 기능 수정

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ trim_trailing_whitespace = true
 
 [*.{kt,kts}]
 indent_size = 4
-max_line_length = 120
+max_line_length = 300
 ij_kotlin_packages_to_use_import_on_demand = unset
 ij_kotlin_name_count_to_use_star_import = 999
 ij_kotlin_name_count_to_use_star_import_for_members = 999

--- a/src/main/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantController.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/controller/myplant/MyPlantController.kt
@@ -42,8 +42,7 @@ class MyPlantController(
         @RequestParam locationId: Long?,
         @RequestParam(defaultValue = "created_desc") sort: String,
         @LoginUser user: User,
-    ): List<MyPlantResponse> =
-        myPlantService.findAllMyPlant(LocalDate.now(), locationId, MyPlantQueryCreteria.from(sort), user)
+    ): List<MyPlantResponse> = myPlantService.findAllMyPlant(LocalDate.now(), locationId, MyPlantQueryCreteria.from(sort), user)
 
     @Secured
     @GetMapping("/{myPlantId}")

--- a/src/main/kotlin/dnd11th/blooming/api/service/guide/GuideService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/guide/GuideService.kt
@@ -5,7 +5,7 @@ import dnd11th.blooming.api.dto.guide.PlantRecommendedPeriodResponse
 import dnd11th.blooming.api.dto.guide.PlantResponse
 import dnd11th.blooming.common.exception.ErrorType
 import dnd11th.blooming.common.exception.NotFoundException
-import dnd11th.blooming.common.util.HangulUtil
+import dnd11th.blooming.common.util.toHangulSearchPattern
 import dnd11th.blooming.domain.repository.PlantRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -17,7 +17,7 @@ class GuideService(
     private val plantMessageFactory: PlantMessageFactory,
 ) {
     fun findPlantList(plantName: String): List<PlantResponse> {
-        val plantList = plantRepository.findByNameMatchesPattern(HangulUtil.getSearchPattern(plantName))
+        val plantList = plantRepository.findByNameMatchesPattern(plantName.toHangulSearchPattern())
 
         return PlantResponse.fromList(plantList)
     }

--- a/src/main/kotlin/dnd11th/blooming/api/service/guide/GuideService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/guide/GuideService.kt
@@ -5,7 +5,7 @@ import dnd11th.blooming.api.dto.guide.PlantRecommendedPeriodResponse
 import dnd11th.blooming.api.dto.guide.PlantResponse
 import dnd11th.blooming.common.exception.ErrorType
 import dnd11th.blooming.common.exception.NotFoundException
-import dnd11th.blooming.common.util.toHangulSearchPattern
+import dnd11th.blooming.common.util.toDecomposedHangul
 import dnd11th.blooming.domain.repository.PlantRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -17,7 +17,7 @@ class GuideService(
     private val plantMessageFactory: PlantMessageFactory,
 ) {
     fun findPlantList(plantName: String): List<PlantResponse> {
-        val plantList = plantRepository.findByNameMatchesPattern(plantName.toHangulSearchPattern())
+        val plantList = plantRepository.findByDecomposedNameLike(plantName.toDecomposedHangul())
 
         return PlantResponse.fromList(plantList)
     }

--- a/src/main/kotlin/dnd11th/blooming/api/service/guide/GuideService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/guide/GuideService.kt
@@ -5,6 +5,7 @@ import dnd11th.blooming.api.dto.guide.PlantRecommendedPeriodResponse
 import dnd11th.blooming.api.dto.guide.PlantResponse
 import dnd11th.blooming.common.exception.ErrorType
 import dnd11th.blooming.common.exception.NotFoundException
+import dnd11th.blooming.common.util.HangulUtil
 import dnd11th.blooming.domain.repository.PlantRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -16,7 +17,7 @@ class GuideService(
     private val plantMessageFactory: PlantMessageFactory,
 ) {
     fun findPlantList(plantName: String): List<PlantResponse> {
-        val plantList = plantRepository.findAllByNameContaining(plantName)
+        val plantList = plantRepository.findByNameMatchesPattern(HangulUtil.getSearchPattern(plantName))
 
         return PlantResponse.fromList(plantList)
     }

--- a/src/main/kotlin/dnd11th/blooming/api/service/guide/StaticPlantMessageFactory.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/guide/StaticPlantMessageFactory.kt
@@ -27,6 +27,5 @@ class StaticPlantMessageFactory(
         month: Month,
     ): PlantGuideSimpleViewResponse = simpleMessageProvider.buildSimpleView(plant, month)
 
-    override fun buildDetailView(plant: Plant): PlantGuideDetailViewResponse =
-        detailMessageProvider.buildDetailView(plant)
+    override fun buildDetailView(plant: Plant): PlantGuideDetailViewResponse = detailMessageProvider.buildDetailView(plant)
 }

--- a/src/main/kotlin/dnd11th/blooming/api/service/guide/provider/HumidityDetailProvider.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/guide/provider/HumidityDetailProvider.kt
@@ -1,7 +1,7 @@
 package dnd11th.blooming.api.service.guide.provider
 
 import dnd11th.blooming.api.dto.guide.DetailHumidityResponse
-import dnd11th.blooming.common.util.HangulUtil.Companion.getEunOrNun
+import dnd11th.blooming.common.util.getEunOrNun
 import dnd11th.blooming.domain.entity.plant.Plant
 import org.springframework.stereotype.Component
 
@@ -21,7 +21,7 @@ class HumidityDetailProvider {
     }
 
     private fun makeDetailHumidityDescription(plant: Plant): String {
-        val eunOrNun = getEunOrNun(plant.korName)
+        val eunOrNun = plant.korName.getEunOrNun()
 
         return "${plant.korName}$eunOrNun ${plant.humidity.humidityLevel}을 좋아해요.\n" +
             "${plant.humidity.displayName}의 습도가 가장 이상적이에요."

--- a/src/main/kotlin/dnd11th/blooming/api/service/guide/provider/HumidityDetailProvider.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/guide/provider/HumidityDetailProvider.kt
@@ -1,7 +1,7 @@
 package dnd11th.blooming.api.service.guide.provider
 
 import dnd11th.blooming.api.dto.guide.DetailHumidityResponse
-import dnd11th.blooming.common.util.KoreanUtil.Companion.getEunOrNun
+import dnd11th.blooming.common.util.HangulUtil.Companion.getEunOrNun
 import dnd11th.blooming.domain.entity.plant.Plant
 import org.springframework.stereotype.Component
 

--- a/src/main/kotlin/dnd11th/blooming/api/service/guide/provider/LightDetailProvider.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/guide/provider/LightDetailProvider.kt
@@ -1,7 +1,7 @@
 package dnd11th.blooming.api.service.guide.provider
 
 import dnd11th.blooming.api.dto.guide.DetailLightResponse
-import dnd11th.blooming.common.util.HangulUtil.Companion.getEunOrNun
+import dnd11th.blooming.common.util.getEunOrNun
 import dnd11th.blooming.domain.entity.plant.Light
 import dnd11th.blooming.domain.entity.plant.Plant
 import org.springframework.stereotype.Component
@@ -27,7 +27,7 @@ class LightDetailProvider {
     }
 
     private fun makeDetailLightAddition(plant: Plant): String {
-        val eunOrNun = getEunOrNun(plant.korName)
+        val eunOrNun = plant.korName.getEunOrNun()
 
         val description =
             when (plant.light) {

--- a/src/main/kotlin/dnd11th/blooming/api/service/guide/provider/LightDetailProvider.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/guide/provider/LightDetailProvider.kt
@@ -1,7 +1,7 @@
 package dnd11th.blooming.api.service.guide.provider
 
 import dnd11th.blooming.api.dto.guide.DetailLightResponse
-import dnd11th.blooming.common.util.KoreanUtil.Companion.getEunOrNun
+import dnd11th.blooming.common.util.HangulUtil.Companion.getEunOrNun
 import dnd11th.blooming.domain.entity.plant.Light
 import dnd11th.blooming.domain.entity.plant.Plant
 import org.springframework.stereotype.Component

--- a/src/main/kotlin/dnd11th/blooming/api/service/guide/provider/PestsDetailProvider.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/guide/provider/PestsDetailProvider.kt
@@ -1,7 +1,7 @@
 package dnd11th.blooming.api.service.guide.provider
 
 import dnd11th.blooming.api.dto.guide.DetailPestsResponse
-import dnd11th.blooming.common.util.KoreanUtil.Companion.getEunOrNun
+import dnd11th.blooming.common.util.HangulUtil.Companion.getEunOrNun
 import dnd11th.blooming.domain.entity.plant.Plant
 import org.springframework.stereotype.Component
 

--- a/src/main/kotlin/dnd11th/blooming/api/service/guide/provider/PestsDetailProvider.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/guide/provider/PestsDetailProvider.kt
@@ -1,7 +1,7 @@
 package dnd11th.blooming.api.service.guide.provider
 
 import dnd11th.blooming.api.dto.guide.DetailPestsResponse
-import dnd11th.blooming.common.util.HangulUtil.Companion.getEunOrNun
+import dnd11th.blooming.common.util.getEunOrNun
 import dnd11th.blooming.domain.entity.plant.Plant
 import org.springframework.stereotype.Component
 
@@ -19,7 +19,7 @@ class PestsDetailProvider {
     }
 
     private fun makeDetailPestsDescription(plant: Plant): String {
-        val eunOrNun = getEunOrNun(plant.korName)
+        val eunOrNun = plant.korName.getEunOrNun()
 
         return "${plant.korName}$eunOrNun ${plant.pests}등에 취약해요. 과습과 건조를 피하고, 환기를 하여 예방하세요."
     }

--- a/src/main/kotlin/dnd11th/blooming/api/service/guide/provider/ToxicityDetailProvider.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/guide/provider/ToxicityDetailProvider.kt
@@ -1,7 +1,7 @@
 package dnd11th.blooming.api.service.guide.provider
 
 import dnd11th.blooming.api.dto.guide.DetailToxicityResponse
-import dnd11th.blooming.common.util.HangulUtil.Companion.getEunOrNun
+import dnd11th.blooming.common.util.getEunOrNun
 import dnd11th.blooming.domain.entity.plant.Plant
 import dnd11th.blooming.domain.entity.plant.Toxicity
 import org.springframework.stereotype.Component
@@ -20,7 +20,7 @@ class ToxicityDetailProvider {
     }
 
     private fun makeDetailToxicityDescription(plant: Plant): String {
-        val eunOrNun = getEunOrNun(plant.korName)
+        val eunOrNun = plant.korName.getEunOrNun()
 
         val description =
             when (plant.toxicity) {

--- a/src/main/kotlin/dnd11th/blooming/api/service/guide/provider/ToxicityDetailProvider.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/guide/provider/ToxicityDetailProvider.kt
@@ -1,7 +1,7 @@
 package dnd11th.blooming.api.service.guide.provider
 
 import dnd11th.blooming.api.dto.guide.DetailToxicityResponse
-import dnd11th.blooming.common.util.KoreanUtil.Companion.getEunOrNun
+import dnd11th.blooming.common.util.HangulUtil.Companion.getEunOrNun
 import dnd11th.blooming.domain.entity.plant.Plant
 import dnd11th.blooming.domain.entity.plant.Toxicity
 import org.springframework.stereotype.Component

--- a/src/main/kotlin/dnd11th/blooming/common/util/HangulUtil.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/util/HangulUtil.kt
@@ -1,53 +1,48 @@
 package dnd11th.blooming.common.util
 
-class HangulUtil {
-    companion object {
-        fun getEunOrNun(str: String): String {
-            return when (isKorStringEndsWithBatchim(str)) {
-                true -> "은"
-                false -> "는"
+private val CHO_SUNG: CharArray = charArrayOf('ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ')
+private val JUNG_SUNG: CharArray = charArrayOf('ㅏ', 'ㅐ', 'ㅑ', 'ㅒ', 'ㅓ', 'ㅔ', 'ㅕ', 'ㅖ', 'ㅗ', 'ㅘ', 'ㅙ', 'ㅚ', 'ㅛ', 'ㅜ', 'ㅝ', 'ㅞ', 'ㅟ', 'ㅠ', 'ㅡ', 'ㅢ', 'ㅣ')
+private val JONG_SUNG: CharArray = charArrayOf('\u0000', 'ㄱ', 'ㄲ', 'ㄳ', 'ㄴ', 'ㄵ', 'ㄶ', 'ㄷ', 'ㄹ', 'ㄺ', 'ㄻ', 'ㄼ', 'ㄽ', 'ㄾ', 'ㄿ', 'ㅀ', 'ㅁ', 'ㅂ', 'ㅄ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ')
+
+fun String.toHangulSearchPattern(): String {
+    return "%${this.toDecomposedHangul()}%"
+}
+
+fun String.toDecomposedHangul(): String {
+    val result = StringBuilder()
+
+    for (c in this.toCharArray()) {
+        if (c in '가'..'힣') { // 한글 완성형
+            val base = c.code - '가'.code
+            // 각 자모를 분리해서
+            val cho = base / (21 * 28)
+            val jung = (base % (21 * 28)) / 28
+            val jong = base % 28
+
+            // 따로따로 추가
+            result.append(CHO_SUNG[cho])
+            result.append(JUNG_SUNG[jung])
+            if (jong != 0) {
+                result.append(JONG_SUNG[jong])
             }
-        }
-
-        private fun isKorStringEndsWithBatchim(str: String): Boolean {
-            if (str.isBlank()) return false
-            val lastChar = str.last()
-            if (lastChar !in '가'..'힣') return false
-            return (lastChar.code - '가'.code) % 28 != 0
-        }
-
-        fun getSearchPattern(hangul: String): String {
-            val decomposedHangul = decomposeHangul(hangul)
-            return "%$decomposedHangul%"
-        }
-
-        private val CHO_SUNG: CharArray =
-            charArrayOf('ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ')
-        private val JUNG_SUNG: CharArray =
-            charArrayOf('ㅏ', 'ㅐ', 'ㅑ', 'ㅒ', 'ㅓ', 'ㅔ', 'ㅕ', 'ㅖ', 'ㅗ', 'ㅘ', 'ㅙ', 'ㅚ', 'ㅛ', 'ㅜ', 'ㅝ', 'ㅞ', 'ㅟ', 'ㅠ', 'ㅡ', 'ㅢ', 'ㅣ')
-        private val JONG_SUNG: CharArray =
-            charArrayOf('\u0000', 'ㄱ', 'ㄲ', 'ㄳ', 'ㄴ', 'ㄵ', 'ㄶ', 'ㄷ', 'ㄹ', 'ㄺ', 'ㄻ', 'ㄼ', 'ㄽ', 'ㄾ', 'ㄿ', 'ㅀ', 'ㅁ', 'ㅂ', 'ㅄ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ')
-
-        private fun decomposeHangul(hangul: String): String {
-            val result = StringBuilder()
-
-            for (c in hangul.toCharArray()) {
-                if (c in '가'..'힣') { // 한글 완성형
-                    val base = c.code - '가'.code
-                    val cho = base / (21 * 28)
-                    val jung = (base % (21 * 28)) / 28
-                    val jong = base % 28
-
-                    result.append(CHO_SUNG[cho]).append(JUNG_SUNG[jung])
-                    if (jong != 0) {
-                        result.append(JONG_SUNG[jong])
-                    }
-                } else {
-                    result.append(c) // 한글이 아닌 문자는 그대로 추가
-                }
-            }
-
-            return result.toString()
+        } else {
+            result.append(c) // 한글 완성형이 아닌 문자는 그대로 추가
         }
     }
+
+    return result.toString()
+}
+
+fun String.getEunOrNun(): String {
+    return when (isKorStringEndsWithBatchim(this)) {
+        true -> "은"
+        false -> "는"
+    }
+}
+
+private fun isKorStringEndsWithBatchim(str: String): Boolean {
+    if (str.isBlank()) return false
+    val lastChar = str.last()
+    if (lastChar !in '가'..'힣') return false
+    return (lastChar.code - '가'.code) % 28 != 0
 }

--- a/src/main/kotlin/dnd11th/blooming/common/util/HangulUtil.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/util/HangulUtil.kt
@@ -4,10 +4,6 @@ private val CHO_SUNG: CharArray = charArrayOf('ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ',
 private val JUNG_SUNG: CharArray = charArrayOf('ㅏ', 'ㅐ', 'ㅑ', 'ㅒ', 'ㅓ', 'ㅔ', 'ㅕ', 'ㅖ', 'ㅗ', 'ㅘ', 'ㅙ', 'ㅚ', 'ㅛ', 'ㅜ', 'ㅝ', 'ㅞ', 'ㅟ', 'ㅠ', 'ㅡ', 'ㅢ', 'ㅣ')
 private val JONG_SUNG: CharArray = charArrayOf('\u0000', 'ㄱ', 'ㄲ', 'ㄳ', 'ㄴ', 'ㄵ', 'ㄶ', 'ㄷ', 'ㄹ', 'ㄺ', 'ㄻ', 'ㄼ', 'ㄽ', 'ㄾ', 'ㄿ', 'ㅀ', 'ㅁ', 'ㅂ', 'ㅄ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ')
 
-fun String.toHangulSearchPattern(): String {
-    return "%${this.toDecomposedHangul()}%"
-}
-
 fun String.toDecomposedHangul(): String {
     val result = StringBuilder()
 

--- a/src/main/kotlin/dnd11th/blooming/common/util/HangulUtil.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/util/HangulUtil.kt
@@ -1,6 +1,6 @@
 package dnd11th.blooming.common.util
 
-class KoreanUtil {
+class HangulUtil {
     companion object {
         fun getEunOrNun(str: String): String {
             return when (isKorStringEndsWithBatchim(str)) {

--- a/src/main/kotlin/dnd11th/blooming/common/util/HangulUtil.kt
+++ b/src/main/kotlin/dnd11th/blooming/common/util/HangulUtil.kt
@@ -15,5 +15,39 @@ class HangulUtil {
             if (lastChar !in '가'..'힣') return false
             return (lastChar.code - '가'.code) % 28 != 0
         }
+
+        fun getSearchPattern(hangul: String): String {
+            val decomposedHangul = decomposeHangul(hangul)
+            return "%$decomposedHangul%"
+        }
+
+        private val CHO_SUNG: CharArray =
+            charArrayOf('ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ')
+        private val JUNG_SUNG: CharArray =
+            charArrayOf('ㅏ', 'ㅐ', 'ㅑ', 'ㅒ', 'ㅓ', 'ㅔ', 'ㅕ', 'ㅖ', 'ㅗ', 'ㅘ', 'ㅙ', 'ㅚ', 'ㅛ', 'ㅜ', 'ㅝ', 'ㅞ', 'ㅟ', 'ㅠ', 'ㅡ', 'ㅢ', 'ㅣ')
+        private val JONG_SUNG: CharArray =
+            charArrayOf('\u0000', 'ㄱ', 'ㄲ', 'ㄳ', 'ㄴ', 'ㄵ', 'ㄶ', 'ㄷ', 'ㄹ', 'ㄺ', 'ㄻ', 'ㄼ', 'ㄽ', 'ㄾ', 'ㄿ', 'ㅀ', 'ㅁ', 'ㅂ', 'ㅄ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ')
+
+        private fun decomposeHangul(hangul: String): String {
+            val result = StringBuilder()
+
+            for (c in hangul.toCharArray()) {
+                if (c in '가'..'힣') { // 한글 완성형
+                    val base = c.code - '가'.code
+                    val cho = base / (21 * 28)
+                    val jung = (base % (21 * 28)) / 28
+                    val jong = base % 28
+
+                    result.append(CHO_SUNG[cho]).append(JUNG_SUNG[jung])
+                    if (jong != 0) {
+                        result.append(JONG_SUNG[jong])
+                    }
+                } else {
+                    result.append(c) // 한글이 아닌 문자는 그대로 추가
+                }
+            }
+
+            return result.toString()
+        }
     }
 }

--- a/src/main/kotlin/dnd11th/blooming/domain/entity/plant/Plant.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/entity/plant/Plant.kt
@@ -1,5 +1,6 @@
 package dnd11th.blooming.domain.entity.plant
 
+import dnd11th.blooming.common.util.toDecomposedHangul
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -61,4 +62,7 @@ class Plant(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null
+
+    @Column
+    val decomposedKorName: String = korName.toDecomposedHangul()
 }

--- a/src/main/kotlin/dnd11th/blooming/domain/repository/PlantRepository.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/repository/PlantRepository.kt
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
 interface PlantRepository : JpaRepository<Plant, Long> {
-    @Query("SELECT p FROM Plant p WHERE p.decomposedkorName LIKE :decomposedKorName")
+    @Query("SELECT p FROM Plant p WHERE p.decomposedKorName LIKE :decomposedKorName")
     fun findByNameMatchesPattern(
         @Param("decomposedKorName") decomposedKorName: String,
     ): List<Plant>

--- a/src/main/kotlin/dnd11th/blooming/domain/repository/PlantRepository.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/repository/PlantRepository.kt
@@ -6,8 +6,8 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
 interface PlantRepository : JpaRepository<Plant, Long> {
-    @Query("SELECT p FROM Plant p WHERE p.korName LIKE %:name% OR p.engName LIKE %:name%")
-    fun findAllByNameContaining(
-        @Param("name") name: String,
+    @Query("SELECT p FROM Plant p WHERE p.decomposedkorName LIKE :decomposedKorName")
+    fun findByNameMatchesPattern(
+        @Param("decomposedKorName") decomposedKorName: String,
     ): List<Plant>
 }

--- a/src/main/kotlin/dnd11th/blooming/domain/repository/PlantRepository.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/repository/PlantRepository.kt
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
 interface PlantRepository : JpaRepository<Plant, Long> {
-    @Query("SELECT p FROM Plant p WHERE p.decomposedKorName LIKE %:keyword% OR p.engName LIKE %:keyword%")
+    @Query("SELECT p FROM Plant p WHERE p.decomposedKorName LIKE :keyword% OR p.engName LIKE :keyword%")
     fun findByDecomposedNameLike(
         @Param("keyword") keyword: String,
     ): List<Plant>

--- a/src/main/kotlin/dnd11th/blooming/domain/repository/PlantRepository.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/repository/PlantRepository.kt
@@ -6,8 +6,8 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
 interface PlantRepository : JpaRepository<Plant, Long> {
-    @Query("SELECT p FROM Plant p WHERE p.decomposedKorName LIKE :decomposedKorName")
-    fun findByNameMatchesPattern(
-        @Param("decomposedKorName") decomposedKorName: String,
+    @Query("SELECT p FROM Plant p WHERE p.decomposedKorName LIKE %:keyword% OR p.engName LIKE %:keyword%")
+    fun findByDecomposedNameLike(
+        @Param("keyword") keyword: String,
     ): List<Plant>
 }

--- a/src/test/kotlin/dnd11th/blooming/api/service/guide/GuideServiceIntegrationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/guide/GuideServiceIntegrationTest.kt
@@ -1,0 +1,84 @@
+package dnd11th.blooming.api.service.guide
+
+import dnd11th.blooming.domain.entity.plant.Difficulty
+import dnd11th.blooming.domain.entity.plant.Fertilizer
+import dnd11th.blooming.domain.entity.plant.GrowLocation
+import dnd11th.blooming.domain.entity.plant.GrowTemperature
+import dnd11th.blooming.domain.entity.plant.Humidity
+import dnd11th.blooming.domain.entity.plant.Light
+import dnd11th.blooming.domain.entity.plant.LowestTemperature
+import dnd11th.blooming.domain.entity.plant.Plant
+import dnd11th.blooming.domain.entity.plant.Toxicity
+import dnd11th.blooming.domain.entity.plant.Water
+import dnd11th.blooming.domain.repository.PlantRepository
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest
+@ActiveProfiles("test")
+class GuideServiceIntegrationTest : DescribeSpec() {
+    @Autowired
+    lateinit var plantRepository: PlantRepository
+
+    @Autowired
+    lateinit var guideService: GuideService
+
+    init {
+        afterEach {
+            plantRepository.deleteAllInBatch()
+        }
+
+        describe("식물 종류 찾기") {
+            plantRepository.saveAll(
+                listOf(
+                    makePlant("몬스테라 델리시오사", "monstera"),
+                    makePlant("몬스테라델리시오사", "monstera"),
+                    makePlant("몬스테라", "monstera"),
+                    makePlant("델리시오사몬스테라", "monstera"),
+                    makePlant("델리시오사 몬스테라", "monstera"),
+                ),
+            )
+            context("한국 이름으로 식물을 검색하면") {
+                val findPlantList = guideService.findPlantList("몬스테라")
+                it("제대로 모든 식물이 조회되어야 한다.") {
+                    findPlantList.size shouldBe 5
+                }
+            }
+            context("글자가 완성되지 않은 채 식물을 검색하면") {
+                val findPlantList = guideService.findPlantList("몬스테ㄹ")
+                it("제대로 모든 식물이 조회되어야 한다.") {
+                    findPlantList.size shouldBe 5
+                }
+            }
+        }
+    }
+
+    fun makePlant(
+        korName: String,
+        engName: String,
+    ): Plant {
+        return Plant(
+            korName = korName,
+            engName = engName,
+            springWater = Water.MOIST,
+            summerWater = Water.MOIST,
+            fallWater = Water.MOIST,
+            winterWater = Water.MOIST,
+            growHeight = 100,
+            growWidth = 100,
+            light = Light.LOW_MEDIUM_HIGH,
+            growTemperature = GrowTemperature.GROW_TEMPERATURE_16_20,
+            toxicity = Toxicity.NOT_EXISTS,
+            humidity = Humidity.HUMIDITY_0_40,
+            fertilizer = Fertilizer.HIGH_DEMAND,
+            lowestTemperature = LowestTemperature.LOWEST_TEMPERATURE_10,
+            difficulty = Difficulty.MEDIUM,
+            location = GrowLocation.ROOM_DARK,
+            pests = "해충1, 해충2",
+            imageUrl = "image.com",
+        )
+    }
+}

--- a/src/test/kotlin/dnd11th/blooming/api/service/guide/GuideServiceIntegrationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/guide/GuideServiceIntegrationTest.kt
@@ -32,17 +32,20 @@ class GuideServiceIntegrationTest : DescribeSpec() {
         }
 
         describe("식물 종류 찾기") {
-            plantRepository.saveAll(
-                listOf(
-                    makePlant("몬스테라 델리시오사", "monstera"),
-                    makePlant("몬스테라델리시오사", "monstera"),
-                    makePlant("몬스테라", "monstera"),
-                    makePlant("델리시오사몬스테라", "monstera"),
-                    makePlant("델리시오사 몬스테라", "monstera"),
-                    makePlant("선인장", "suninjang"),
-                    makePlant("전혀 다른 식물", "kiki"),
-                ),
-            )
+            beforeTest {
+                plantRepository.saveAll(
+                    listOf(
+                        makePlant("몬스테라 델리시오사", "monstera"),
+                        makePlant("몬스테라델리시오사", "monstera"),
+                        makePlant("몬스테라", "monstera"),
+                        makePlant("델리시오사몬스테라", "monstera"),
+                        makePlant("델리시오사 몬스테라", "monstera"),
+                        makePlant("선인장", "suninjang"),
+                        makePlant("전혀 다른 식물", "kiki"),
+                    ),
+                )
+            }
+
             context("한글 이름으로 식물을 검색하면") {
                 val findPlantList = guideService.findPlantList("몬스테라")
                 it("제대로 모든 식물이 조회되어야 한다.") {
@@ -62,7 +65,7 @@ class GuideServiceIntegrationTest : DescribeSpec() {
                 }
             }
             context("영어명으로 검색하면") {
-                val findPlantList = guideService.findPlantList("monstrera")
+                val findPlantList = guideService.findPlantList("monstera")
                 it("제대로 모든 식물이 조회되어야 한다.") {
                     findPlantList.size shouldBe 5
                 }
@@ -80,7 +83,7 @@ class GuideServiceIntegrationTest : DescribeSpec() {
                 }
             }
             context("영어명의 중간부분으로 검색하면") {
-                val findPlantList = guideService.findPlantList("stre")
+                val findPlantList = guideService.findPlantList("ste")
                 it("제대로 모든 식물이 조회되어야 한다.") {
                     findPlantList.size shouldBe 5
                 }

--- a/src/test/kotlin/dnd11th/blooming/api/service/guide/GuideServiceIntegrationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/guide/GuideServiceIntegrationTest.kt
@@ -49,13 +49,13 @@ class GuideServiceIntegrationTest : DescribeSpec() {
             context("한글 이름으로 식물을 검색하면") {
                 val findPlantList = guideService.findPlantList("몬스테라")
                 it("제대로 모든 식물이 조회되어야 한다.") {
-                    findPlantList.size shouldBe 5
+                    findPlantList.size shouldBe 3
                 }
             }
             context("초성만 적고 식물을 검색하면") {
                 val findPlantList = guideService.findPlantList("몬스테ㄹ")
                 it("제대로 모든 식물이 조회되어야 한다.") {
-                    findPlantList.size shouldBe 5
+                    findPlantList.size shouldBe 3
                 }
             }
             context("중성까지 적고 식물을 검색하면") {
@@ -78,14 +78,14 @@ class GuideServiceIntegrationTest : DescribeSpec() {
             }
             context("영어명의 뒷부분으로만 검색하면") {
                 val findPlantList = guideService.findPlantList("era")
-                it("제대로 모든 식물이 조회되어야 한다.") {
-                    findPlantList.size shouldBe 5
+                it("조회되면 안된다.") {
+                    findPlantList.size shouldBe 0
                 }
             }
             context("영어명의 중간부분으로 검색하면") {
                 val findPlantList = guideService.findPlantList("ste")
                 it("제대로 모든 식물이 조회되어야 한다.") {
-                    findPlantList.size shouldBe 5
+                    findPlantList.size shouldBe 0
                 }
             }
         }

--- a/src/test/kotlin/dnd11th/blooming/api/service/guide/GuideServiceIntegrationTest.kt
+++ b/src/test/kotlin/dnd11th/blooming/api/service/guide/GuideServiceIntegrationTest.kt
@@ -39,16 +39,48 @@ class GuideServiceIntegrationTest : DescribeSpec() {
                     makePlant("몬스테라", "monstera"),
                     makePlant("델리시오사몬스테라", "monstera"),
                     makePlant("델리시오사 몬스테라", "monstera"),
+                    makePlant("선인장", "suninjang"),
+                    makePlant("전혀 다른 식물", "kiki"),
                 ),
             )
-            context("한국 이름으로 식물을 검색하면") {
+            context("한글 이름으로 식물을 검색하면") {
                 val findPlantList = guideService.findPlantList("몬스테라")
                 it("제대로 모든 식물이 조회되어야 한다.") {
                     findPlantList.size shouldBe 5
                 }
             }
-            context("글자가 완성되지 않은 채 식물을 검색하면") {
+            context("초성만 적고 식물을 검색하면") {
                 val findPlantList = guideService.findPlantList("몬스테ㄹ")
+                it("제대로 모든 식물이 조회되어야 한다.") {
+                    findPlantList.size shouldBe 5
+                }
+            }
+            context("중성까지 적고 식물을 검색하면") {
+                val findPlantList = guideService.findPlantList("선인자")
+                it("제대로 모든 식물이 조회되어야 한다.") {
+                    findPlantList.size shouldBe 1
+                }
+            }
+            context("영어명으로 검색하면") {
+                val findPlantList = guideService.findPlantList("monstrera")
+                it("제대로 모든 식물이 조회되어야 한다.") {
+                    findPlantList.size shouldBe 5
+                }
+            }
+            context("영어명의 앞부분으로만 검색하면") {
+                val findPlantList = guideService.findPlantList("monst")
+                it("제대로 모든 식물이 조회되어야 한다.") {
+                    findPlantList.size shouldBe 5
+                }
+            }
+            context("영어명의 뒷부분으로만 검색하면") {
+                val findPlantList = guideService.findPlantList("era")
+                it("제대로 모든 식물이 조회되어야 한다.") {
+                    findPlantList.size shouldBe 5
+                }
+            }
+            context("영어명의 중간부분으로 검색하면") {
+                val findPlantList = guideService.findPlantList("stre")
                 it("제대로 모든 식물이 조회되어야 한다.") {
                     findPlantList.size shouldBe 5
                 }


### PR DESCRIPTION
> ### How
- 한글유틸에 코틀린 DSL 스타일로 한글을 분해하는 확장함수를 만들었습니다.
- 식물 객체를 생성할 때 자동으로 한글명을 분해하여 저장되는 decomposedKorName 필드를 만들었습니다.
- 식물 종류를 검색할 때 검색키워드로 받아온 문자열을 분해하여 쿼리합니다.

> ### Result
- 이제 한글을 제대로 인식하여 검색할 수 있습니다.
- 앞으로 지역명등에서도 같은 방법으로 검색할 수 있습니다.
