### PR TITLE
[BLOOM-114] 지역검색 쿼리 fulltext search 적용

### DIFF
--- a/docker/blooming-container/docker-compose.local.yml
+++ b/docker/blooming-container/docker-compose.local.yml
@@ -11,6 +11,8 @@ services:
       MYSQL_DATABASE: blooming
       MYSQL_ROOT_PASSWORD: 1234
       TZ: "Asia/Seoul"
+    volumes:
+      - ./my.cnf:/etc/my.cnf
     command:
       - --character-set-server=utf8
       - --collation-server=utf8_general_ci

--- a/docker/blooming-container/my.cnf
+++ b/docker/blooming-container/my.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+ngram_token_size=1

--- a/src/main/kotlin/dnd11th/blooming/api/service/region/RegionService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/region/RegionService.kt
@@ -4,13 +4,20 @@ import dnd11th.blooming.api.dto.region.RegionResponse
 import dnd11th.blooming.domain.entity.region.Region
 import dnd11th.blooming.domain.repository.region.RegionRepository
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
+@Transactional(readOnly = true)
 class RegionService(
     private val regionRepository: RegionRepository,
 ) {
     companion object {
         private const val DEFAULT_PAGE_SIZE = 30
+        private val jamoSet =
+            setOf(
+                'ㄱ', 'ㄴ', 'ㄷ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅅ', 'ㅇ', 'ㅈ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ',
+                'ㅏ', 'ㅑ', 'ㅓ', 'ㅕ', 'ㅗ', 'ㅛ', 'ㅜ', 'ㅠ', 'ㅡ', 'ㅣ',
+            )
     }
 
     fun findRegion(name: String): List<RegionResponse> {
@@ -20,8 +27,17 @@ class RegionService(
     }
 
     fun createSearchQuery(input: String): String {
-        return input.split(" ")
+        return input
+            .removeLastJamoIfOneWord()
+            .split(" ")
             .filter { it.isNotBlank() }
             .joinToString(" ") { "+$it" }
+    }
+
+    fun String.removeLastJamoIfOneWord(): String {
+        if (this.length > 1 && this.last() in jamoSet) {
+            return this.dropLast(1)
+        }
+        return this
     }
 }

--- a/src/main/kotlin/dnd11th/blooming/api/service/region/RegionService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/region/RegionService.kt
@@ -15,7 +15,7 @@ class RegionService(
 
     fun findRegion(name: String): List<RegionResponse> {
         val searchQuery = createSearchQuery(name)
-        val regions: List<Region> = regionRepository.findByNameContaining2(searchQuery, DEFAULT_PAGE_SIZE)
+        val regions: List<Region> = regionRepository.findByNameContaining(searchQuery, DEFAULT_PAGE_SIZE)
         return regions.stream().map { region -> RegionResponse.from(region) }.toList()
     }
 

--- a/src/main/kotlin/dnd11th/blooming/api/service/region/RegionService.kt
+++ b/src/main/kotlin/dnd11th/blooming/api/service/region/RegionService.kt
@@ -3,8 +3,6 @@ package dnd11th.blooming.api.service.region
 import dnd11th.blooming.api.dto.region.RegionResponse
 import dnd11th.blooming.domain.entity.region.Region
 import dnd11th.blooming.domain.repository.region.RegionRepository
-import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 
 @Service
@@ -12,13 +10,18 @@ class RegionService(
     private val regionRepository: RegionRepository,
 ) {
     companion object {
-        private const val DEFAULT_PAGE_NUMBER = 0
         private const val DEFAULT_PAGE_SIZE = 30
     }
 
     fun findRegion(name: String): List<RegionResponse> {
-        val pageable: Pageable = PageRequest.of(DEFAULT_PAGE_NUMBER, DEFAULT_PAGE_SIZE)
-        val regions: List<Region> = regionRepository.findByNameContaining(name, pageable)
+        val searchQuery = createSearchQuery(name)
+        val regions: List<Region> = regionRepository.findByNameContaining2(searchQuery, DEFAULT_PAGE_SIZE)
         return regions.stream().map { region -> RegionResponse.from(region) }.toList()
+    }
+
+    fun createSearchQuery(input: String): String {
+        return input.split(" ")
+            .filter { it.isNotBlank() }
+            .joinToString(" ") { "+$it" }
     }
 }

--- a/src/main/kotlin/dnd11th/blooming/domain/repository/region/RegionRepository.kt
+++ b/src/main/kotlin/dnd11th/blooming/domain/repository/region/RegionRepository.kt
@@ -1,12 +1,22 @@
 package dnd11th.blooming.domain.repository.region
 
 import dnd11th.blooming.domain.entity.region.Region
-import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface RegionRepository : JpaRepository<Region, Int> {
+    @Query(
+        value = """
+        SELECT *
+        FROM region
+        WHERE MATCH(name) AGAINST(:searchQuery IN BOOLEAN MODE)
+        LIMIT :limit
+        """,
+        nativeQuery = true,
+    )
     fun findByNameContaining(
-        name: String,
-        pageable: Pageable,
+        @Param("searchQuery") searchQuery: String,
+        @Param("limit") limit: Int,
     ): List<Region>
 }


### PR DESCRIPTION
<!-- 제목은 아래처럼 -->
<!-- [BLOOM-001] PR 제목 -->
Close #114 
> ### How
<!-- 해당 테스크를 수행하기 위한 과정과 흐름에 대해 집중해서 작성해주세요. -->
- 지역 검색 쿼리에 FullText Search를 적용하였습니다.
- 현재 지역 검색 쿼리는 LIKE '%지역명% 방식이었습니다. 해당 방식은 와일드카드가 앞에 존재함으로서 인덱스를 적용하기 어렵고, '서울 송파' 와 같은 쿼리 시에는 아무런 값도 반환하지 않는 문제점이 존재합니다.
> ### Result
<!-- 해당 테스크를 통한 결과에 대해 짧게 작성해주세요. -->
<!-- 작업한 내용, 스크린샷 -->
- FullTextIndex의 ngram parser를 적용하였습니다.
- 해당 방식은 Text에 대해 토큰 사이즈만큼 자른 후 인덱스를 생성하는 방식입니다.(Ngram token size는 1로 설정했습니다)

- '서울 가락'과 같은 방식으로 검색 시 다음과 같은 쿼리를 생성하고 올바른 결과를 반환합니다.
`SELECT id, name FROM region WHERE MATCH(region.name) AGAINST('+서울 +가락' IN BOOLEAN MODE)`
![스크린샷 2024-09-16 오후 4 28 21](https://github.com/user-attachments/assets/18be8a07-6182-457d-a1d9-57cbab0ab32a)

- 속도 차이는 다음과 같습니다.
사진의 첫번째 줄 마지막 시간이 해당 쿼리가 완료된 시간(ms)인데요. 여러번 실행의 평균값을 놓는다고 해도 20ms->0.5ms로 97.5% 성능 개선이 이루어졌습니다.
  - LIKE문
    `EXPLAIN ANALYZE SELECT id, name FROM region WHERE name LIKE '%송파%' LIMIT 30;`
  ![스크린샷 2024-09-16 오후 4 38 47](https://github.com/user-attachments/assets/0f566fce-146e-41f4-9cd6-5f1c594cb8d7)
  - FullText Index
  `EXPLAIN ANALYZE SELECT id, name FROM region WHERE MATCH(region.name) AGAINST('+송파' IN BOOLEAN MODE) LIMIT 30;`
  ![스크린샷 2024-09-16 오후 4 37 40](https://github.com/user-attachments/assets/b77f5b55-3e01-4516-9c77-df11a2da4d3c)

> ### 고민사항
다음과 같은 내용을 고민했습니다.
- 자모분리를 사용하지 않은 이유
  식물 검색시 처럼 자모분리를 해서 검색을 진행하려고 했으나 다음과 같은 문제가 있었습니다.
   - 'ㅅㅓ'를 검색한 결과입니다. IndexFull Search를 할 시 '서'가 포함된 모든 칼럼들이 순서를 고려하지 않고 반환되어서 사용자에게 혼란을 줄 수 있다고 생각했습니다.
    `SELECT id, name FROM region WHERE MATCH(region.decomposed_name) AGAINST('+ㅅㅓ' IN BOOLEAN MODE) LIMIT 30;`
![스크린샷 2024-09-16 오후 4 52 17](https://github.com/user-attachments/assets/7755fa8b-90ca-42a8-aab8-1d9303cc8b5b)
  - 'ㅅㅓ'를 검색시 '성'이 포함되는 글자도 같이 검색이 되게 됩니다. 식물 검색과 같은 경우는 모르기 때문 혹은 정보를 찾기 위해 검색을 하지만, 주소 검색은 아는 주소를 빠르게 검색하는 것이 우선이기 때문에 자모분리를 하지 않는 것이 낫다고 판단했습니다.
- Prefix Index를 사용할까 고민했습니다.
  - '서울특별시', '경기도'와 같은 1단계 지역과 '송파구'와 같은 2단계 지역구에 대해 인덱스를 설정하여 주소값을 빠르게 찾는 방법을 생각했습니다. 실제 1단계 지역구는 큰 카디널리티를 보여주었습니다.
  - 하지만 '서'를 검색했을 시 1단계, 2단계, 3단계 지역구에 대해 모두 검색이 이루어져야하기 떄문에 UNION을 사용해야했고, UNION과정에서 쿼리가 느려져 유의미한 개선이 이루어지지 않았습니다.

