### PR TITLE
[BLOOM-122] 전역 예외처리 추가

### DIFF
--- a/api/src/main/kotlin/dnd11th/blooming/api/controller/exception/GlobalExceptionHandler.kt
+++ b/api/src/main/kotlin/dnd11th/blooming/api/controller/exception/GlobalExceptionHandler.kt
@@ -23,7 +23,7 @@ class GlobalExceptionHandler {
     fun handleMyException(exception: MyException): ResponseEntity<ErrorResponse> {
         val errorType = exception.errorType
 
-        logException(errorType, exception)
+        logException(errorType, exception, ExceptionSource.BLOOMING)
 
         return ResponseEntity
             .status(errorType.status)
@@ -34,7 +34,7 @@ class GlobalExceptionHandler {
     fun handleArgumentValidationException(exception: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
         val errorType = ErrorType.BAD_REQUEST
 
-        logException(errorType, exception)
+        logException(errorType, exception, ExceptionSource.HTTP)
 
         // bindingResult를 순회하며 errorArgumentMap을 채운다.
         val fieldErrorList: List<FieldErrorResponse> =
@@ -63,9 +63,7 @@ class GlobalExceptionHandler {
     fun handleMessageNotReadableException(exception: HttpMessageNotReadableException): ResponseEntity<ErrorResponse> {
         val errorType = ErrorType.HTTP_MESSAGE_NOT_READABLE
 
-        logException(errorType, exception)
-
-        log.info { "Http Exception: ${errorType.message}, Exception: $exception" }
+        logException(errorType, exception, ExceptionSource.HTTP)
 
         return ResponseEntity
             .status(errorType.status)
@@ -76,9 +74,7 @@ class GlobalExceptionHandler {
     fun handleMethodNotSupportedException(exception: HttpRequestMethodNotSupportedException): ResponseEntity<ErrorResponse> {
         val errorType = ErrorType.HTTP_METHOD_NOT_SUPPORTED
 
-        logException(errorType, exception)
-
-        log.info { "Http Exception: ${errorType.message}, Exception: $exception" }
+        logException(errorType, exception, ExceptionSource.HTTP)
 
         return ResponseEntity
             .status(errorType.status)
@@ -89,9 +85,7 @@ class GlobalExceptionHandler {
     fun handleMissingPathVariableException(exception: MissingPathVariableException): ResponseEntity<ErrorResponse> {
         val errorType = ErrorType.PATH_VARIABLE_MISSING
 
-        logException(errorType, exception)
-
-        log.info { "Http Exception: ${errorType.message}, Exception: $exception" }
+        logException(errorType, exception, ExceptionSource.HTTP)
 
         return ResponseEntity
             .status(errorType.status)
@@ -102,9 +96,7 @@ class GlobalExceptionHandler {
     fun handleMissingServletRequestParameterException(exception: MissingServletRequestParameterException): ResponseEntity<ErrorResponse> {
         val errorType = ErrorType.REQUEST_PARAMETER_MISSING
 
-        logException(errorType, exception)
-
-        log.info { "Http Exception: ${errorType.message}, Exception: $exception" }
+        logException(errorType, exception, ExceptionSource.HTTP)
 
         return ResponseEntity
             .status(errorType.status)
@@ -115,9 +107,7 @@ class GlobalExceptionHandler {
     fun handleArgumentTypeMismatchException(exception: MethodArgumentTypeMismatchException): ResponseEntity<ErrorResponse> {
         val errorType = ErrorType.ARUGMENT_TYPE_MISMATCH
 
-        logException(errorType, exception)
-
-        log.info { "Http Exception: ${errorType.message}, Exception: $exception" }
+        logException(errorType, exception, ExceptionSource.HTTP)
 
         return ResponseEntity
             .status(errorType.status)
@@ -127,19 +117,17 @@ class GlobalExceptionHandler {
     private fun logException(
         errorType: ErrorType,
         exception: Exception,
+        exceptionSource: ExceptionSource,
     ) {
         when (errorType.logLevel) {
-            LogLevel.ERROR -> {
-                log.error { "Blooming Exception: ${errorType.message}, Exception: $exception" }
-            }
-
-            LogLevel.WARN -> {
-                log.warn { "Blooming Exception: ${errorType.message}, Exception: $exception" }
-            }
-
-            else -> {
-                log.info { "Blooming Exception: ${errorType.message}, Exception: $exception" }
-            }
+            LogLevel.ERROR -> log.error { "$exceptionSource Exception: ${errorType.message}, Exception: $exception" }
+            LogLevel.WARN -> log.warn { "$exceptionSource Exception: ${errorType.message}, Exception: $exception" }
+            else -> log.info { "$exceptionSource Exception: ${errorType.message}, Exception: $exception" }
         }
+    }
+
+    private enum class ExceptionSource {
+        BLOOMING,
+        HTTP,
     }
 }

--- a/api/src/main/kotlin/dnd11th/blooming/api/controller/exception/GlobalExceptionHandler.kt
+++ b/api/src/main/kotlin/dnd11th/blooming/api/controller/exception/GlobalExceptionHandler.kt
@@ -7,6 +7,7 @@ import dnd11th.blooming.common.exception.MyException
 import dnd11th.blooming.common.util.Logger.Companion.log
 import org.springframework.boot.logging.LogLevel
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.validation.FieldError
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -17,17 +18,9 @@ class GlobalExceptionHandler {
     @ExceptionHandler(MyException::class)
     fun handleMyException(exception: MyException): ResponseEntity<ErrorResponse> {
         val errorType = exception.errorType
-        when (errorType.logLevel) {
-            LogLevel.ERROR -> {
-                log.error { "Blooming Exception: ${errorType.message}, Exception: $exception" }
-            }
-            LogLevel.WARN -> {
-                log.warn { "Blooming Exception: ${errorType.message}, Exception: $exception" }
-            }
-            else -> {
-                log.info { "Blooming Exception: ${errorType.message}, Exception: $exception" }
-            }
-        }
+
+        logException(errorType, exception)
+
         return ResponseEntity
             .status(errorType.status)
             .body(ErrorResponse.from(errorType))
@@ -36,6 +29,8 @@ class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleArgumentValidationException(exception: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
         val errorType = ErrorType.BAD_REQUEST
+
+        logException(errorType, exception)
 
         // bindingResult를 순회하며 errorArgumentMap을 채운다.
         val fieldErrorList: List<FieldErrorResponse> =
@@ -58,5 +53,37 @@ class GlobalExceptionHandler {
         return ResponseEntity
             .status(exception.statusCode)
             .body(ErrorResponse.from(errorType, fieldErrorList))
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun handleMessageNotReadableException(exception: HttpMessageNotReadableException): ResponseEntity<ErrorResponse> {
+        val errorType = ErrorType.HTTP_MESSAGE_NOT_READABLE
+
+        logException(errorType, exception)
+
+        log.info { "Blooming Exception: ${errorType.message}, Exception: $exception" }
+
+        return ResponseEntity
+            .status(errorType.status)
+            .body(ErrorResponse.from(errorType))
+    }
+
+    private fun logException(
+        errorType: ErrorType,
+        exception: Exception,
+    ) {
+        when (errorType.logLevel) {
+            LogLevel.ERROR -> {
+                log.error { "Blooming Exception: ${errorType.message}, Exception: $exception" }
+            }
+
+            LogLevel.WARN -> {
+                log.warn { "Blooming Exception: ${errorType.message}, Exception: $exception" }
+            }
+
+            else -> {
+                log.info { "Blooming Exception: ${errorType.message}, Exception: $exception" }
+            }
+        }
     }
 }

--- a/api/src/main/kotlin/dnd11th/blooming/api/controller/exception/GlobalExceptionHandler.kt
+++ b/api/src/main/kotlin/dnd11th/blooming/api/controller/exception/GlobalExceptionHandler.kt
@@ -9,6 +9,7 @@ import org.springframework.boot.logging.LogLevel
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.validation.FieldError
+import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -61,7 +62,20 @@ class GlobalExceptionHandler {
 
         logException(errorType, exception)
 
-        log.info { "Blooming Exception: ${errorType.message}, Exception: $exception" }
+        log.info { "Http Exception: ${errorType.message}, Exception: $exception" }
+
+        return ResponseEntity
+            .status(errorType.status)
+            .body(ErrorResponse.from(errorType))
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
+    fun handleMethodNotSupportedException(exception: HttpRequestMethodNotSupportedException): ResponseEntity<ErrorResponse> {
+        val errorType = ErrorType.HTTP_METHOD_NOT_SUPPORTED
+
+        logException(errorType, exception)
+
+        log.info { "Http Exception: ${errorType.message}, Exception: $exception" }
 
         return ResponseEntity
             .status(errorType.status)

--- a/api/src/main/kotlin/dnd11th/blooming/api/controller/exception/GlobalExceptionHandler.kt
+++ b/api/src/main/kotlin/dnd11th/blooming/api/controller/exception/GlobalExceptionHandler.kt
@@ -15,6 +15,7 @@ import org.springframework.web.bind.MissingPathVariableException
 import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
@@ -100,6 +101,19 @@ class GlobalExceptionHandler {
     @ExceptionHandler(MissingServletRequestParameterException::class)
     fun handleMissingServletRequestParameterException(exception: MissingServletRequestParameterException): ResponseEntity<ErrorResponse> {
         val errorType = ErrorType.REQUEST_PARAMETER_MISSING
+
+        logException(errorType, exception)
+
+        log.info { "Http Exception: ${errorType.message}, Exception: $exception" }
+
+        return ResponseEntity
+            .status(errorType.status)
+            .body(ErrorResponse.from(errorType))
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+    fun handleArgumentTypeMismatchException(exception: MethodArgumentTypeMismatchException): ResponseEntity<ErrorResponse> {
+        val errorType = ErrorType.ARUGMENT_TYPE_MISMATCH
 
         logException(errorType, exception)
 

--- a/api/src/main/kotlin/dnd11th/blooming/api/controller/exception/GlobalExceptionHandler.kt
+++ b/api/src/main/kotlin/dnd11th/blooming/api/controller/exception/GlobalExceptionHandler.kt
@@ -12,6 +12,7 @@ import org.springframework.validation.FieldError
 import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.MissingPathVariableException
+import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
@@ -84,8 +85,21 @@ class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(MissingPathVariableException::class)
-    fun handleMethodNotSupportedException(exception: MissingPathVariableException): ResponseEntity<ErrorResponse> {
+    fun handleMissingPathVariableException(exception: MissingPathVariableException): ResponseEntity<ErrorResponse> {
         val errorType = ErrorType.PATH_VARIABLE_MISSING
+
+        logException(errorType, exception)
+
+        log.info { "Http Exception: ${errorType.message}, Exception: $exception" }
+
+        return ResponseEntity
+            .status(errorType.status)
+            .body(ErrorResponse.from(errorType))
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException::class)
+    fun handleMissingServletRequestParameterException(exception: MissingServletRequestParameterException): ResponseEntity<ErrorResponse> {
+        val errorType = ErrorType.REQUEST_PARAMETER_MISSING
 
         logException(errorType, exception)
 

--- a/api/src/main/kotlin/dnd11th/blooming/api/controller/exception/GlobalExceptionHandler.kt
+++ b/api/src/main/kotlin/dnd11th/blooming/api/controller/exception/GlobalExceptionHandler.kt
@@ -11,6 +11,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.validation.FieldError
 import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingPathVariableException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
@@ -72,6 +73,19 @@ class GlobalExceptionHandler {
     @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
     fun handleMethodNotSupportedException(exception: HttpRequestMethodNotSupportedException): ResponseEntity<ErrorResponse> {
         val errorType = ErrorType.HTTP_METHOD_NOT_SUPPORTED
+
+        logException(errorType, exception)
+
+        log.info { "Http Exception: ${errorType.message}, Exception: $exception" }
+
+        return ResponseEntity
+            .status(errorType.status)
+            .body(ErrorResponse.from(errorType))
+    }
+
+    @ExceptionHandler(MissingPathVariableException::class)
+    fun handleMethodNotSupportedException(exception: MissingPathVariableException): ResponseEntity<ErrorResponse> {
+        val errorType = ErrorType.PATH_VARIABLE_MISSING
 
         logException(errorType, exception)
 

--- a/common/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
+++ b/common/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
@@ -11,6 +11,7 @@ enum class ErrorType(val status: HttpStatus, var message: String, val logLevel: 
     HTTP_METHOD_NOT_SUPPORTED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP METHOD 입니다.", LogLevel.DEBUG),
     PATH_VARIABLE_MISSING(HttpStatus.BAD_REQUEST, "경로 변수가 누락되었습니다.", LogLevel.DEBUG),
     REQUEST_PARAMETER_MISSING(HttpStatus.BAD_REQUEST, "요청 파라미터가 누락되었습니다.", LogLevel.DEBUG),
+    ARUGMENT_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "경로 변수 혹은 요청 파라미터 타입이 올바르지 않습니다.", LogLevel.DEBUG),
 
     // MyPlant
     NOT_FOUND_MYPLANT(HttpStatus.NOT_FOUND, "존재하지 않는 내 식물입니다.", LogLevel.DEBUG),

--- a/common/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
+++ b/common/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
@@ -10,6 +10,7 @@ enum class ErrorType(val status: HttpStatus, var message: String, val logLevel: 
     HTTP_MESSAGE_NOT_READABLE(HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다.", LogLevel.DEBUG),
     HTTP_METHOD_NOT_SUPPORTED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP METHOD 입니다.", LogLevel.DEBUG),
     PATH_VARIABLE_MISSING(HttpStatus.BAD_REQUEST, "경로 변수가 누락되었습니다.", LogLevel.DEBUG),
+    REQUEST_PARAMETER_MISSING(HttpStatus.BAD_REQUEST, "요청 파라미터가 누락되었습니다.", LogLevel.DEBUG),
 
     // MyPlant
     NOT_FOUND_MYPLANT(HttpStatus.NOT_FOUND, "존재하지 않는 내 식물입니다.", LogLevel.DEBUG),

--- a/common/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
+++ b/common/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
@@ -7,6 +7,7 @@ enum class ErrorType(val status: HttpStatus, var message: String, val logLevel: 
     // COMMON
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error has occurred.", LogLevel.ERROR),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "요청 파라미터가 올바르지 않습니다.", LogLevel.DEBUG),
+    HTTP_MESSAGE_NOT_READABLE(HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다.", LogLevel.DEBUG),
 
     // MyPlant
     NOT_FOUND_MYPLANT(HttpStatus.NOT_FOUND, "존재하지 않는 내 식물입니다.", LogLevel.DEBUG),

--- a/common/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
+++ b/common/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
@@ -9,6 +9,7 @@ enum class ErrorType(val status: HttpStatus, var message: String, val logLevel: 
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "요청 파라미터가 올바르지 않습니다.", LogLevel.DEBUG),
     HTTP_MESSAGE_NOT_READABLE(HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다.", LogLevel.DEBUG),
     HTTP_METHOD_NOT_SUPPORTED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP METHOD 입니다.", LogLevel.DEBUG),
+    PATH_VARIABLE_MISSING(HttpStatus.BAD_REQUEST, "경로 변수가 누락되었습니다.", LogLevel.DEBUG),
 
     // MyPlant
     NOT_FOUND_MYPLANT(HttpStatus.NOT_FOUND, "존재하지 않는 내 식물입니다.", LogLevel.DEBUG),

--- a/common/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
+++ b/common/src/main/kotlin/dnd11th/blooming/common/exception/ErrorType.kt
@@ -8,6 +8,7 @@ enum class ErrorType(val status: HttpStatus, var message: String, val logLevel: 
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error has occurred.", LogLevel.ERROR),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "요청 파라미터가 올바르지 않습니다.", LogLevel.DEBUG),
     HTTP_MESSAGE_NOT_READABLE(HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다.", LogLevel.DEBUG),
+    HTTP_METHOD_NOT_SUPPORTED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP METHOD 입니다.", LogLevel.DEBUG),
 
     // MyPlant
     NOT_FOUND_MYPLANT(HttpStatus.NOT_FOUND, "존재하지 않는 내 식물입니다.", LogLevel.DEBUG),


### PR DESCRIPTION
> ### How
- 다음과 같은 전역 예외 처리를 추가하였습니다.
  - HttpMessageNotReadableException : 요청 json 형식이 잘못되었을 경우
  - HttpRequestMethodNotSupportedException : http method가 지원되지 않을 경우
  - MissingPathVariableException : 경로 변수가 누락되었을 경우
  - MissingServletRequestParameterException : 요청 파라미터가 누락되었을 경우
  - MethodArgumentTypeMismatchException : 경로 변수 / 요청 파리미터의 형식이 올바르지 않은 경우
- 전역 예외 처리에서 로깅하는 코드를 공통화시켰습니다.

> ### Result
- 이제 단순한 요청 실수에도 커스텀된 응답 메시지를 반환해줄 수 있습니다.

Resolves #122 