### PR TITLE
[BLOOM-128] 이미지 삭제 api 수정

### DIFF
--- a/api/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageApi.kt
+++ b/api/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageApi.kt
@@ -2,6 +2,7 @@ package dnd11th.blooming.api.controller.image
 
 import dnd11th.blooming.api.annotation.ApiErrorResponse
 import dnd11th.blooming.api.annotation.ApiErrorResponses
+import dnd11th.blooming.api.dto.image.ImageDeleteRequest
 import dnd11th.blooming.api.dto.image.ImageFavoriteModifyRequest
 import dnd11th.blooming.api.dto.image.ImageSaveRequest
 import dnd11th.blooming.common.exception.ErrorType
@@ -48,8 +49,8 @@ interface ImageApi {
     @ApiResponse(responseCode = "200", description = "이미지 삭제 성공")
     @ApiErrorResponse(errorType = ErrorType.NOT_FOUND_IMAGE, description = "id에 해당하는 이미지를 찾지 못했을 때 에러입니다.")
     fun deleteImage(
-        @Parameter(description = "이미지 ID", required = true)
-        imageId: Long,
+        @RequestBody(description = "이미지 삭제 요청", required = true)
+        request: ImageDeleteRequest,
         @Schema(hidden = true)
         user: User,
     )

--- a/api/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
+++ b/api/src/main/kotlin/dnd11th/blooming/api/controller/image/ImageController.kt
@@ -2,6 +2,7 @@ package dnd11th.blooming.api.controller.image
 
 import dnd11th.blooming.api.annotation.LoginUser
 import dnd11th.blooming.api.annotation.Secured
+import dnd11th.blooming.api.dto.image.ImageDeleteRequest
 import dnd11th.blooming.api.dto.image.ImageFavoriteModifyRequest
 import dnd11th.blooming.api.dto.image.ImageSaveRequest
 import dnd11th.blooming.api.service.image.ImageService
@@ -37,9 +38,11 @@ class ImageController(
     ) = imageService.modifyFavorite(imageId, request.favorite!!, user)
 
     @Secured
-    @DeleteMapping("/image/{imageId}")
+    @DeleteMapping("/image")
     override fun deleteImage(
-        @PathVariable imageId: Long,
+        @RequestBody request: ImageDeleteRequest,
         @LoginUser user: User,
-    ) = imageService.deleteImage(imageId, user)
+    ) {
+        imageService.deleteImage(request.imageIds!!, user)
+    }
 }

--- a/api/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageDeleteRequest.kt
+++ b/api/src/main/kotlin/dnd11th/blooming/api/dto/image/ImageDeleteRequest.kt
@@ -1,0 +1,14 @@
+package dnd11th.blooming.api.dto.image
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+
+@Schema(
+    name = "Image Delete Request",
+    description = "이미지 삭제 요청",
+)
+data class ImageDeleteRequest(
+    @field:Schema(description = "삭제할 이미지 ID", example = "[1, 2, 3]")
+    @field:NotNull(message = "삭제할 이미지 ID는 필수입니다.")
+    val imageIds: List<Long>?,
+)

--- a/api/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
+++ b/api/src/main/kotlin/dnd11th/blooming/api/service/image/ImageService.kt
@@ -47,13 +47,11 @@ class ImageService(
 
     @Transactional
     fun deleteImage(
-        imageId: Long,
+        imageIds: List<Long>,
         user: User,
     ) {
-        val image =
-            imageRepository.findByIdAndUser(imageId, user)
-                ?: throw NotFoundException(ErrorType.NOT_FOUND_IMAGE)
+        val images = imageRepository.findByUserAndIdsIn(imageIds, user)
 
-        imageRepository.delete(image)
+        imageRepository.deleteAllInBatch(images)
     }
 }

--- a/domain/core/src/main/kotlin/dnd11th/blooming/core/repository/image/ImageRepository.kt
+++ b/domain/core/src/main/kotlin/dnd11th/blooming/core/repository/image/ImageRepository.kt
@@ -57,4 +57,14 @@ interface ImageRepository : JpaRepository<Image, Long> {
         @Param("imageId") imageId: Long,
         @Param("user") user: User,
     ): Image?
+
+    @Query(
+        """
+	SELECT i from Image i WHERE i.id In :imageIds and i.myPlant.user = :user
+	""",
+    )
+    fun findByUserAndIdsIn(
+        @Param("imageIds") imageIds: List<Long>,
+        @Param("user") user: User,
+    ): List<Image>
 }


### PR DESCRIPTION
> ### How
- Path Variable 대신에 Request Body를 통해 동시에 여러 이미지 id들을 받을 수 있도록 했습니다.
- 해당 이미지들을 동시에 삭제합니다.

> ### Result
- 이제 이미지 삭제 api에서 여러 이미지를 동시에 삭제할 수 있게 되었습니다.

Resolves #128 